### PR TITLE
Use dark background for table header

### DIFF
--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -71,7 +71,7 @@
     background-color: #282828 !important;
   }
 
-  table.wikitable > tr > th, table.wikitable > * > tr > th {
+  table.wikitable > tr > th, table.wikitable > * > tr > th, div.barbox > table > tbody > tr > th {
     background-color: #333; /* don't include !important flag */
   }
 


### PR DESCRIPTION
[Example](https://en.wikipedia.org/wiki/Kobo_eReader#Market_share)