### PR TITLE
Add dark background to even rows of infobox

### DIFF
--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -67,7 +67,7 @@
 
   table[style*="background-color:#fff;"], .search-form fieldset, table.ambox, tr[style*="background-color: #fff;"],
   .mw-ui-button[style*="background-color:#008B6D"], tr[style*="background-color: #f5faff;"],
-  tr[style*="background:#E9E9E9"] > * {
+  tr[style*="background:#E9E9E9"] > *, table.infobox.hproduct > tbody > tr:nth-child(2n+4) {
     background-color: #282828 !important;
   }
 


### PR DESCRIPTION
[Example](https://en.wikipedia.org/wiki/EarthBound)

The default CSS uses alternating colors between the even and odd rows so I did the same thing here.