### PR TITLE
Darkened The Background For Musical Tracks

### DIFF
--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -123,6 +123,19 @@
   td[style*="background:#F2F2F2"], table.wikitable > tbody > tr[style*="background-color:#F6F6F6"] {
     background-color: #333 !important;
   }
+  
+  .tracklist {
+    background: transparent !important;
+  }
+  
+  .tlheader {
+    background: #333333 !important;
+  }
+  
+  .tracklist > tbody > tr {
+    background: #222222 !important;
+    border: solid #555555 1px !important;
+  }
 
   /* remove background image/gradient */
   .keyboard-key, div#editpage-specialchars a, body div.ui-dialog .ui-widget-header {


### PR DESCRIPTION
Musical Tracks had a white background and light grey text, which made it difficult to read. The .tracklist panel extended too far to the right, so I made it transparent. I then made the header for the track list a grey color (#333333), and the background for the tracks a darker grey (#222222) with a light grey border (#555555). It fits the design pattern, formatted correctly, and does not cause any issues with other portions of the site (as far as I am aware).