### PR TITLE
Invert color of black loudspeaker icon

### DIFF
--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -302,6 +302,11 @@
   table[style*="border:4px ridge"], .jfk-bubble-closebtn {
     border: none !important;
   }
+  
+  /* Loudspeaker icon */
+  .unicode.haudio a img {
+    filter: invert(60%);
+  }
 
   /*** diff pages ***/
   .diff-context {


### PR DESCRIPTION
This is for the icons next to the pronunciation links. I just created this rule so I think some testing is in order, but so far I haven't noticed it inverting any icons that should be left alone.

Here is the [example page](https://en.wikipedia.org/wiki/Wikipedia) - you should see the speaker icons next to where it explains how to pronounce Wikipedia.