### PR TITLE
fix tooltip/reversed

### DIFF
--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -247,14 +247,19 @@
   .mwe-popups.flipped-y:before, .mwe-popups.flipped-x-y:before {
     border-top-color: #555 !important;
   }
-  .mwe-popups:after {
+  .mwe-popups:after,
+  .oo-ui-popupWidget-anchored-top .oo-ui-popupWidget-anchor:before,
+  .oo-ui-popupWidget-anchored-top .oo-ui-popupWidget-anchor:after {
     border-bottom-color: #222 !important;
   }
   .mwe-popups.flipped_y:after, .mwe-popups.flipped_x_y:after,
-  .mwe-popups.flipped-y:after, .mwe-popups.flipped-x-y:after {
+  .mwe-popups.flipped-y:after, .mwe-popups.flipped-x-y:after,
+  .oo-ui-popupWidget-anchored-bottom .oo-ui-popupWidget-anchor:before,
+  .oo-ui-popupWidget-anchored-bottom .oo-ui-popupWidget-anchor:after {
     border-top-color: #222 !important;
   }
-  .mwe-popups, .mwe-popups-is-not-tall, .mwe-popups-is-tall {
+  .mwe-popups, .mwe-popups-is-not-tall, .mwe-popups-is-tall,
+  .oo-ui-popupWidget-popup {
     border: 1px solid #555 !important;
   }
   .mwe-popups-settings-icon:hover, .mwe-popups-settings-icon:active {

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -281,20 +281,6 @@
   .referencetooltip > li + li {
     border-top: 12px #555 solid !important;
   }
- 
-  .referencetooltip.RTflipped > li + li {
-    position: absolute !important;
-    top: 8px !important;
-    border-top: 0 !important;
-    border-bottom: 8px #222 solid !important;
-  }
-
-  .referencetooltip.RTflipped > li + li::after {
-    border-top: 0 !important;
-    border-bottom: 8px #222 solid !important;
-    position: absolute !important;
-    margin-top: -3px !important;
-  }
 
   /* Bookmark Icon */
   #ca-watch.icon a {

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -258,12 +258,36 @@
     border-bottom: #555 1px solid !important;
   }
 
+  .referencetooltip > li {
+    background: #222 !important;
+    border: 1px solid #555 !important;
+  }
+
   /* arrow down */
   .referencetooltip > li + li, .referencetooltip > li + li::after {
-    border-top-color: #555 !important;
+    border-top-color: #222 !important;
     border-right-color: transparent !important;
     border-left-color: transparent !important;
   }
+
+  .referencetooltip > li + li {
+    border-top: 12px #555 solid !important;
+  }
+ 
+  .referencetooltip.RTflipped > li + li {
+    position: absolute !important;
+    top: 8px !important;
+    border-top: 0 !important;
+    border-bottom: 8px #222 solid !important;
+  }
+
+  .referencetooltip.RTflipped > li + li::after {
+    border-top: 0 !important;
+    border-bottom: 8px #222 solid !important;
+    position: absolute !important;
+    margin-top: -3px !important;
+  }
+
   /* Bookmark Icon */
   #ca-watch.icon a {
     background-image: url('data:image/svg+xml,<%3Fxml%20version%3D"1.0"%20encoding%3D"UTF-8"%3F><svg%20xmlns%3D"http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg"%20width%3D"16"%20height%3D"16"><path%20d%3D"M8.103%201.146l2.175%204.408%204.864.707-3.52%203.431.831%204.845-4.351-2.287-4.351%202.287.831-4.845-3.52-3.431%204.864-.707z"%20fill%3D"transparent"%20stroke%3D"%237cb5d1"%20stroke-width%3D"1"%2F><%2Fsvg>') !important;

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -242,25 +242,23 @@
   .mwe-popups:before {
     border-bottom-color: #555 !important;
   }
-  .mwe-popups.flipped_y:before,
-  .mwe-popups.flipped_x_y:before,
+  .mwe-popups.flipped_y:before, .mwe-popups.flipped_x_y:before,
   .wikiEditor-toolbar-dialog .ui-dialog-buttonpane,
-  .mwe-popups.flipped-y:before,
-  .mwe-popups.flipped-x-y:before {
+  .mwe-popups.flipped-y:before, .mwe-popups.flipped-x-y:before {
     border-top-color: #555 !important;
   }
   .mwe-popups:after {
     border-bottom-color: #222 !important;
   }
-  .mwe-popups.flipped_y:after,
-  .mwe-popups.flipped_x_y:after,
-  .mwe-popups.flipped-y:after,
-  .mwe-popups.flipped-x-y:after {
+  .mwe-popups.flipped_y:after, .mwe-popups.flipped_x_y:after,
+  .mwe-popups.flipped-y:after, .mwe-popups.flipped-x-y:after {
     border-top-color: #222 !important;
   }
   .mwe-popups, .mwe-popups-is-not-tall, .mwe-popups-is-tall {
-    background-color: #222 !important;
     border: 1px solid #555 !important;
+  }
+  .mwe-popups-settings-icon:hover, .mwe-popups-settings-icon:active {
+    background-color: #444 !important;
   }
 
   div.vectorTabs li:not(.selected), .oo-ui-popupWidget-anchor:after,

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -258,6 +258,10 @@
   .mwe-popups.flipped-x-y:after {
     border-top-color: #222 !important;
   }
+  .mwe-popups, .mwe-popups-is-not-tall, .mwe-popups-is-tall {
+    background-color: #222 !important;
+    border: 1px solid #555 !important;
+  }
 
   div.vectorTabs li:not(.selected), .oo-ui-popupWidget-anchor:after,
   .oo-ui-popupWidget-head {

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -289,7 +289,7 @@
     border-bottom-color: #222 !important;
   }
   .referencetooltip.RTflipped > li + li::after {
-    border-bottom-color:  transparent !important;
+    border-bottom-color: transparent !important;
   }
 
   /* Bookmark Icon */

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -21,7 +21,7 @@
 
   /*** Overall ***/
   td, p, li, th:not([style*="background"]), caption, div,
-  span:not([class*="color"]):not([class*="wikEd"]):not([style*="background"]),
+  p span:not([class*="color"]):not([class*="wikEd"]):not([style*="background"]),
   p code, label code, dl code, .oo-ui-widget div, .oo-ui-widget label {
     color: #9a9a9a;
   }

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -21,7 +21,7 @@
 
   /*** Overall ***/
   td, p, li, th:not([style*="background"]), caption, div,
-  p span:not([class*="color"]):not([class*="wikEd"]):not([style*="background"]),
+  span:not([class*="color"]):not([class*="wikEd"]):not([style*="background"]),
   p code, label code, dl code, .oo-ui-widget div, .oo-ui-widget label {
     color: #9a9a9a;
   }

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -277,9 +277,14 @@
     border-right-color: transparent !important;
     border-left-color: transparent !important;
   }
-
   .referencetooltip > li + li {
     border-top: 12px #555 solid !important;
+  }
+  .referencetooltip.RTflipped > li + li {
+    border-bottom-color: #222 !important;
+  }
+  .referencetooltip.RTflipped > li + li::after {
+    border-bottom-color:  transparent !important;
   }
 
   /* Bookmark Icon */

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -242,14 +242,20 @@
   .mwe-popups:before {
     border-bottom-color: #555 !important;
   }
-  .mwe-popups.flipped_y:before, .mwe-popups.flipped_x_y:before,
-  .wikiEditor-toolbar-dialog .ui-dialog-buttonpane {
+  .mwe-popups.flipped_y:before,
+  .mwe-popups.flipped_x_y:before,
+  .wikiEditor-toolbar-dialog .ui-dialog-buttonpane,
+  .mwe-popups.flipped-y:before,
+  .mwe-popups.flipped-x-y:before {
     border-top-color: #555 !important;
   }
   .mwe-popups:after {
     border-bottom-color: #222 !important;
   }
-  .mwe-popups.flipped_y:after, .mwe-popups.flipped_x_y:after {
+  .mwe-popups.flipped_y:after,
+  .mwe-popups.flipped_x_y:after,
+  .mwe-popups.flipped-y:after,
+  .mwe-popups.flipped-x-y:after {
     border-top-color: #222 !important;
   }
 


### PR DESCRIPTION
![tooltip](https://user-images.githubusercontent.com/31389848/41553411-a64831c2-7329-11e8-84c8-ede56c0a8cf2.gif)

I was trying to find this one 

![capture](https://user-images.githubusercontent.com/31389848/41553429-b39f6f20-7329-11e8-8975-5e8f54846d6c.PNG)

But cant grab with inspect and css from style editor was nothing I could see useful.

So ended up fixing the others :( that I could find, sadly had to add as is else theres arrows flying outside the box, anyway Ive lost my plot with these tooltips. Argh!
