### PR TITLE
Updating variant of #F0F0F0

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -35,7 +35,7 @@
 }
 @preprocessor uso
 ==/UserStyle== */
-@-moz-document domain("wikipedia.org"), domain("wikidata.org"), domain("mediawiki.org"), domain("wiktionary.org") {
+@-moz-document domain("wikipedia.org"), domain("wikidata.org"), domain("mediawiki.org"), domain("wiktionary.org"), domain("wiki.rpcs3.net") {
   /* Modified from https://userstyles.org/styles/47161/dark-wikipedia-rounded */
   :root {
     --base-color: /*[[base-color]]*/;
@@ -163,7 +163,7 @@
   tr[style*="background-color: #f5faff;" i],
   tr[style*="background:#E9E9E9" i] > *,
   table.infobox.hproduct > tbody > tr[style*="background: #F0F0F0;" i],
-  table > tbody > tr[style*="background:#f0f0f0;" i],
+  tr[style*="background:#f0f0f0;" i],
   td[style*="background:lightyellow" i], td[style*="background:#eeeeff" i],
   td[style*="background:#ddddff" i], .oo-ui-buttonElement-button:hover,
   .tracklist tr[style*="background-color:#f7f7f7" i],

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -150,7 +150,8 @@
   .wikitable.charts-zebragrey > tbody > tr:nth-of-type(odd),
   td > span[style*="background-color:#eee" i],
   #mw-content-text div:not(.toctitle) > h2, table.flextable th,
-  tr[style*="background-color:#FFF" i], td[style*="background:#eee" i] {
+  tr[style*="background-color:#FFF" i], td[style*="background:#eee" i],
+  #mw-searchoptions {
     background-color: #222 !important;
   }
   body .ui-button {
@@ -161,7 +162,7 @@
   tr[style*="background-color: #fff;" i],
   .mw-ui-button[style*="background-color:#008B6D" i],
   tr[style*="background-color: #f5faff;" i],
-  tr[style*="background:#E9E9E9" i] > *,
+  tr[style*="background:#E9E9E9" i], th[style*="background:#E9E9E9" i],
   table.infobox.hproduct > tbody > tr[style*="background: #F0F0F0;" i],
   tr[style*="background:#f0f0f0;" i],
   td[style*="background:lightyellow" i], td[style*="background:#eeeeff" i],

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -163,6 +163,7 @@
   tr[style*="background-color: #f5faff;" i],
   tr[style*="background:#E9E9E9" i] > *,
   table.infobox.hproduct > tbody > tr[style*="background: #F0F0F0;" i],
+  table > tbody > tr[style*="background:#f0f0f0;" i],
   td[style*="background:lightyellow" i], td[style*="background:#eeeeff" i],
   td[style*="background:#ddddff" i], .oo-ui-buttonElement-button:hover,
   .tracklist tr[style*="background-color:#f7f7f7" i],


### PR DESCRIPTION
When using this dark theme with the wiki of RPCS3 (PS3 emulator) [https://wiki.rpcs3.net/] the infobox escapes the theme due to absence of this #f0f0f0 variant. Hope this is okay.

Here's a [link](https://wiki.rpcs3.net/index.php?title=God_of_War:_Collection) to see this happening.

<details>
 <summary>Before</summary>

![before](https://user-images.githubusercontent.com/31934788/45895638-5a065d00-bdef-11e8-8efe-f506c709c65d.png)
</details>
<details>
 <summary>After</summary>

![after](https://user-images.githubusercontent.com/31934788/45895637-596dc680-bdef-11e8-9511-7673b4128ef6.png)
</details>

Do let me know if anything else is required!