### PR TITLE
Extending the dark theme to cover the scrollbar

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -443,4 +443,19 @@
   .oo-ui-icon-bell, .mw-widget-calendarWidget-day-additional {
     opacity: .7 !important;
   }
+  /* scroll bar */
+  ::-webkit-scrollbar {
+    max-width: 10px !important;
+    max-height: 10px !important;
+    background: #1d1d1d !important;
+  }
+  ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner {
+    background: #1d1d1d !important;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: rgba(175, 175, 175, .5) !important;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: rgba(65, 131, 196, .8) !important;
+  }
 }


### PR DESCRIPTION
I was trying to add dark theme for the scrollbar when I noticed your GitHub dark theme already has a neat version of it. So I've decided to use that instead and only removed GitHub specific portions. As with that theme, this addition only works on Chrome.

<details>
 <summary>Before</summary>

![before](https://user-images.githubusercontent.com/31934788/46205902-f4125c00-c33f-11e8-9456-7aff9957b673.png)
</details>
<details>
 <summary>After</summary>

![after](https://user-images.githubusercontent.com/31934788/46205903-f4125c00-c33f-11e8-849a-d1216af8015e.png)
</details>

Do let me know if anything else is required!