### PR TITLE
Fix plainlinks table and infobox links

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -120,7 +120,7 @@
   .ui-widget-overlay {
     background: rgba(0, 0, 0, .8) !important;
   }
-  #bodyContent pre, #bodyContent code, span.plainlinks * {
+  #bodyContent pre, #bodyContent code, span.plainlinks {
     background-color: #111 !important;
     border-color: #555 !important;
     color: #b9b9b9 !important;
@@ -181,7 +181,7 @@
   td[style*="background: #ececec;" i], th[style*="background:#eee" i],
   th[style*="background-color: #eee" i],
   tr[style*="background-color: #f7f7f7;" i], th[style*="background:#F2F2F2" i],
-  #filetoc, .toccolours, th[style*="background:#F9F9F9" i], table.plainlinks,
+  #filetoc, .toccolours, th[style*="background:#F9F9F9" i],
   th[style*="background-color: lightgrey" i], th[style*="background:#ddd" i],
   .infobox th[style*="background"], .infobox td[style*="background"],
   td[style*="background:#F2F2F2" i],


### PR DESCRIPTION
Ran into 2 cases of plainlinks not being displayed correctly:

1. The [version page](https://en.wikipedia.org/wiki/Special:Version) tables display fully with the header background colour. I've found that removing 'table.plainlinks' solves this. This line was added as part of the [initial commit](https://github.com/StylishThemes/Wikipedia-Dark/commit/33f62f3f81b5aa2ae1428cc3cd18c4ef2efd2fbd) itself so I'm not sure what it was meant to address. Hopefully doesn't break anything.

<details>
 <summary>Before</summary>

![before1](https://user-images.githubusercontent.com/31934788/46474006-6b903180-c7ff-11e8-9c29-d22976d77ee0.png)
</details>
<details>
 <summary>After</summary>

![after1](https://user-images.githubusercontent.com/31934788/46474020-75199980-c7ff-11e8-8c3a-23b65a6b410e.png)
</details>
<br />

2. While using plainlinks in the [infobox of RPCS3 wiki](https://wiki.rpcs3.net/index.php?title=Catherine), I noticed links display pure white instead of blue. Removing '*' from 'span.plainlinks' address this problem. This line was added in this [commit](https://github.com/StylishThemes/Wikipedia-Dark/commit/76067e1eb19800b3e948319952cdc058943ae434).

<details>
 <summary>Before</summary>

![before2](https://user-images.githubusercontent.com/31934788/46474051-85317900-c7ff-11e8-9793-d8ebaaec5640.png)
</details>
<details>
 <summary>After</summary>

![after2](https://user-images.githubusercontent.com/31934788/46474061-8a8ec380-c7ff-11e8-8302-9fce9b22c958.png)
</details>
<br />

I'm not too sure why these 2 lines were added so any inputs would be greatly appreciated. Do let me know if any further details are required.