### PR TITLE
Add background color for user message pop-ups

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -187,7 +187,7 @@
   td[style*="background:#F2F2F2" i],
   table.wikitable > tbody > tr[style*="background-color:#F6F6F6" i], .tlheader,
   th[style*="background:whitesmoke" i], td[style*="background:whitesmoke" i],
-  th[style*="#FFEBAD" i] {
+  th[style*="#FFEBAD" i], .usermessage {
     background-color: #333 !important;
   }
   /* remove background image/gradient */
@@ -266,10 +266,6 @@
   #mp-center h2, #mp-center h2 span, .table-partial,
   tr[style*="background:orange" i], td[style*="background:#ffd" i] {
     background-color: #321 !important;
-  }
-  /* Grey */
-  .usermessage {
-    background-color: #333 !important;
   }
   /*** Border ***/
   fieldset, button[type="submit"] {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -269,7 +269,7 @@
   }
   /* Grey */
   .usermessage {
-    background-color: #3a3a3a !important;
+    background-color: #333 !important;
   }
   /*** Border ***/
   fieldset, button[type="submit"] {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -232,7 +232,7 @@
   #mp-left h2, #mp-left h2 span, td[style*="background: #99FF99;" i], .table-yes,
   td[style*="background:#dfd" i], td[style*="background:#bfd" i],
   tr[style*="background:#DDFFDD" i], tr[style*="background:#bfb" i],
-  tr[style*="background-color:#CCFFCC" i], .usermessage {
+  tr[style*="background-color:#CCFFCC" i] {
     background: #244024 !important;
     color: #ddd !important;
   }
@@ -266,6 +266,10 @@
   #mp-center h2, #mp-center h2 span, .table-partial,
   tr[style*="background:orange" i], td[style*="background:#ffd" i] {
     background-color: #321 !important;
+  }
+  /* Grey */
+  .usermessage {
+    background-color: #3a3a3a !important;
   }
   /*** Border ***/
   fieldset, button[type="submit"] {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -232,7 +232,7 @@
   #mp-left h2, #mp-left h2 span, td[style*="background: #99FF99;" i], .table-yes,
   td[style*="background:#dfd" i], td[style*="background:#bfd" i],
   tr[style*="background:#DDFFDD" i], tr[style*="background:#bfb" i],
-  tr[style*="background-color:#CCFFCC" i] {
+  tr[style*="background-color:#CCFFCC" i], .usermessage {
     background: #244024 !important;
     color: #ddd !important;
   }


### PR DESCRIPTION
Message notifications that show up as a banner in the wiki page does not have a background making it pretty easy to miss. Added a background to let it stand out.

Original white theme
![white](https://user-images.githubusercontent.com/31934788/46585602-744b6680-ca90-11e8-9a4f-0c0f30e5c511.png)

Before
![before](https://user-images.githubusercontent.com/31934788/46585606-79101a80-ca90-11e8-956a-4a7256b1d925.png)

After
![after](https://user-images.githubusercontent.com/31934788/46585608-7d3c3800-ca90-11e8-9359-4e1685d95393.png)

Let me know if you have any comments!