### PR TITLE
Added extension infobox + misc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wikipedia Dark
 
-Applies to wikipedia.org, wikidata.org, mediawiki.org &amp; wiktionary.org
+Applies to wikipedia.org, wikidata.org, mediawiki.org, wikimedia.org &amp; wiktionary.org
 
 ## Preview
 

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -245,9 +245,22 @@ domain("wiki.rpcs3.net") {
   #mp-left h2, #mp-left h2 span, td[style*="background: #99FF99;" i], .table-yes,
   td[style*="background:#dfd" i], td[style*="background:#bfd" i],
   tr[style*="background:#DDFFDD" i], tr[style*="background:#bfb" i],
-  tr[style*="background-color:#CCFFCC" i] {
-    background: #244024 !important;
+  tr[style*="background-color:#CCFFCC" i],
+  table.ext-status-stable > tbody > tr.tpl-infobox-header {
+    background: #165316 !important;
     color: #ddd !important;
+  }
+  /* Yellow */
+  table.ext-status-beta > tbody > tr.tpl-infobox-header {
+    background: #b28200 !important;
+  }
+  /* Orange */
+  table.ext-status-experimental > tbody > tr.tpl-infobox-header {
+    background: #e53e00 !important;
+  }
+  /* Grey */
+  table.ext-status-unknown > tbody > tr.tpl-infobox-header {
+    background: #555 !important;
   }
   /* Blue */
   div[style*="background"] h2, div[style*="background"] h2 *, #mp-right h2,
@@ -372,7 +385,8 @@ domain("wiki.rpcs3.net") {
   }
   /*** Text ***/
   .wikitable tr:not([style*="color:black" i]) th:not([style*="color: black" i]),
-  table.wikitable > tbody > tr[style*="background-color:#F6F6F6" i] > td > * {
+  table.wikitable > tbody > tr[style*="background-color:#F6F6F6" i] > td > * ,
+  tr.ext-infobox-header th, tr.ext-infobox-header span {
     color: #fff !important;
   }
   .CategoryTreeEmptyBullet, .table-na, .infobox {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -184,7 +184,7 @@ domain("wiki.rpcs3.net") {
   h2[style*="background:#efefef" i], tr[bgcolor*="#eee" i],
   tr[style*="background-color:#eee" i],
   .wikitable.charts-zebragrey > tbody > tr:nth-of-type(even),
-  tr[style*="background:#fbf8d6" i], table.flextable td {
+  tr[style*="background:#fbf8d6" i], table.flextable td, table.nmbox td {
     background-color: #282828 !important;
   }
   table.wikitable > tr > th, table.wikitable > * > tr > th,
@@ -200,7 +200,7 @@ domain("wiki.rpcs3.net") {
   td[style*="background:#F2F2F2" i],
   table.wikitable > tbody > tr[style*="background-color:#F6F6F6" i], .tlheader,
   th[style*="background:whitesmoke" i], td[style*="background:whitesmoke" i],
-  th[style*="#FFEBAD" i], .usermessage {
+  th[style*="#FFEBAD" i], .usermessage, table.nmbox th {
     background-color: #333 !important;
   }
   /* remove background image/gradient */


### PR DESCRIPTION
Hi, I made a couple changes.

1. Firstly, the infobox headers for extension weren't being captured by the theme. Here's an [example](https://www.mediawiki.org/wiki/Extension:Cargo) of it at work.

<details>
 <summary>Before</summary>

![Before](https://user-images.githubusercontent.com/31934788/49138265-c1bbb580-f314-11e8-8f8b-238fc336b1b5.png)
</details>
<details>
 <summary>After</summary>

![After](https://user-images.githubusercontent.com/31934788/49138282-cbddb400-f314-11e8-930b-f904d436f020.png)
</details>
<br />

2. The current green seemed a tad too dark to me. I feel it doesn't show the positive nature of the extension being stable. So I opted to make it a mildly lighter shade that stays true to the theme and gives the look I was expecting. However, I understand that this boils down to tastes, so if you don't like it, I'll drop this commit.

<details>
<summary>Before</summary>

![Before](https://user-images.githubusercontent.com/31934788/49138479-41498480-f315-11e8-9bb2-24ec5c110f42.png)
</details>
<details>
<summary>After</summary>

![After](https://user-images.githubusercontent.com/31934788/49138519-5a523580-f315-11e8-94e8-7ee91ef945f9.png)
</details>
<br />

3. Added wikimedia.org to the README since it is also supported now.

4. Also added support for nmbox tables that are found in almost every extensions page in mediawiki.org. You can find one at the bottom of the Cargo extension page linked above as well.

Let me know what you guys think!