### PR TITLE
Remove dedicated scrollbar code and add Overlay-Scrollbars to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Then install using one of these methods:
 📦 [Install the usercss](https://github.com/StylishThemes/Wikipedia-Dark/raw/master/wikipedia-dark.user.css) with Stylus or xStyle. Supports automatic updates.<br>
 📦 [Install from userstyles.org](https://userstyles.org/styles/105844) with customization, does not support automatic updates **(NO LONGER UPDATED)**.<br>
 
+## Additional Userstyles
+
+⚙️ [Overlay-Scrollbars](https://github.com/StylishThemes/Overlay-Scrollbars)<br>
+
 ## Limitations
 
 * Many of the table cells have inline styling to add a background colors.

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -476,19 +476,4 @@ domain("wiki.rpcs3.net") {
   .oo-ui-icon-bell, .mw-widget-calendarWidget-day-additional {
     opacity: .7 !important;
   }
-  /* scroll bar */
-  ::-webkit-scrollbar {
-    max-width: 10px !important;
-    max-height: 10px !important;
-    background: #1d1d1d !important;
-  }
-  ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner {
-    background: #1d1d1d !important;
-  }
-  ::-webkit-scrollbar-thumb {
-    background: rgba(175, 175, 175, .5) !important;
-  }
-  ::-webkit-scrollbar-thumb:hover {
-    background: var(--base-color-8) !important;
-  }
 }


### PR DESCRIPTION
Since a [dedicated scrollbar theme](https://github.com/StylishThemes/Overlay-Scrollbars) has been made, there is no longer a need to have it as part of this theme. 

The new style allows users to customise the scrollbar from the extension itself and works on Firefox as well. So I think it is a better solution to point users to it rather than baking it into this theme.