### PR TITLE
Fix reference tooltip colours

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -476,4 +476,11 @@ domain("wiki.rpcs3.net") {
   .oo-ui-icon-bell, .mw-widget-calendarWidget-day-additional {
     opacity: .7 !important;
   }
+  /*** Reference tooltips ***/
+  .rt-tooltip, .rt-tooltipTail:after {
+    background: #222 !important;
+  }
+  .rt-tooltipTail {
+    background: #555 !important;
+  }
 }


### PR DESCRIPTION
**Screenshots...**

**Before:**
![wikipedia-dark-reference-tooltip-before](https://user-images.githubusercontent.com/13129485/55695643-89de1200-5987-11e9-97d3-68075a9c7693.png)

**After:**
![wikipedia-dark-reference-tooltip-after](https://user-images.githubusercontent.com/13129485/55695646-8ba7d580-5987-11e9-99de-9b3afeb4ffd1.png)