### PR TITLE
Make nav menu logo adjustments Wikipedia-specific

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -453,6 +453,19 @@ domain("wiki.rpcs3.net") {
   .central-featured-logo {
     filter: brightness(60.5%) !important;
   }
+  .oo-ui-icon-bell, .mw-widget-calendarWidget-day-additional {
+    opacity: .7 !important;
+  }
+  /*** Reference tooltips ***/
+  .rt-tooltip, .rt-tooltipTail:after {
+    background: #222 !important;
+  }
+  .rt-tooltipTail {
+    background: #555 !important;
+  }
+}
+@-moz-document domain("wikipedia.org") {
+  /*** Navigation menu logo ***/
   #p-logo a {
     background-position: center -155px !important;
     display: table-cell !important;
@@ -473,14 +486,5 @@ domain("wiki.rpcs3.net") {
     filter: invert(60.5%) !important;
     height: 47px !important;
   }
-  .oo-ui-icon-bell, .mw-widget-calendarWidget-day-additional {
-    opacity: .7 !important;
-  }
-  /*** Reference tooltips ***/
-  .rt-tooltip, .rt-tooltipTail:after {
-    background: #222 !important;
-  }
-  .rt-tooltipTail {
-    background: #555 !important;
   }
 }


### PR DESCRIPTION
StylishThemes/Wikipedia-Dark#30's changes were designed specifically with wikipedia.org in mind. When this repo's domains were later expanded to cover more than just wikipedia.org, the other domains' navigation menu logos got messed up.

This commit adds an extra @document rule specifically for wikipedia.org and moves the nav menu logo adjustments to it. Didn't move the main index page overrides there since they weren't breaking anything on the other domains.

**Wiktionary screenshots:**

**Before:**
![wiktionary-nav-menu-logo-before](https://user-images.githubusercontent.com/13129485/55697606-18569180-5990-11e9-8f5f-ec11cf0fdbfd.png)

**After:**
![wiktionary-nav-menu-logo-after](https://user-images.githubusercontent.com/13129485/55697607-1987be80-5990-11e9-8b66-bf8f55480a14.png)