### PR TITLE
Fix selected item colour in revision history

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -69,7 +69,8 @@ domain("wiki.rpcs3.net") {
   /*** Overall ***/
   td, p, li, th:not([style*="background"]), caption, div,
   span:not([class*="color"]):not([class*="wikEd"]):not([style*="background"]):not([class*="oo-ui-labelElement-label"]),
-  p code, label code, dl code, .oo-ui-widget div, .oo-ui-widget label {
+  p code, label code, dl code, .oo-ui-widget div, .oo-ui-widget label,
+  #pagehistory li.selected {
     color: #9a9a9a;
   }
   body, h1, h2, h3, h4, h5, h6, #footer li, .infobox th[style*="background"],


### PR DESCRIPTION
Causes bullets and "m" ("This is a minor edit" indicator) on selected list items to appear as light grey instead of dark grey.

**Comparison screenshots ([Sega: Revision history](https://en.wikipedia.org/w/index.php?title=Sega&action=history)):**

**Before:**
![wikipedia-revision-history-before](https://user-images.githubusercontent.com/13129485/56783801-82a66900-67bb-11e9-902d-8311b4f3872b.png)

**After:**
![wikipedia-revision-history-after](https://user-images.githubusercontent.com/13129485/56783803-84702c80-67bb-11e9-8352-526deb84b5d5.png)