### PR TITLE
Fix quotes in Russian articles

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -428,7 +428,7 @@ domain("wiki.rpcs3.net") {
     color: #ff4242 !important;
   }
   /*** Quotes ***/
-  .ts-Начало_цитаты-quote {
+  blockquote {
     background-color: transparent !important;
     border: none !important;
   }

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -427,6 +427,11 @@ domain("wiki.rpcs3.net") {
   .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:hover {
     color: #ff4242 !important;
   }
+  /*** Quotes ***/
+  .ts-Начало_цитаты-quote {
+    background-color: transparent !important;
+    border: none !important;
+  }
   /*** Misc ***/
   #p-cactions li.selected a, #p-cactions li a, #p-cactions li a:hover {
     padding: 0 1em .1em !important;


### PR DESCRIPTION
I've found that many articles in Russian (I didn't see this in English ones) don't apply dark style to their quotes. For example: Martin Niemöller's article (https://ru.wikipedia.org/wiki/Нимёллер,_Мартин)
Before:
![1](https://user-images.githubusercontent.com/14265316/57738816-b1787680-76b9-11e9-884b-d181d55c2271.png)
After:
![2](https://user-images.githubusercontent.com/14265316/57738822-b806ee00-76b9-11e9-9dc9-a8fa69c4e492.png)