### PR TITLE
Better list of wikimedia sites

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -39,8 +39,18 @@
 @-moz-document domain("wikipedia.org"),
 domain("wikidata.org"),
 domain("mediawiki.org"),
-domain("wikimedia.org"),
+domain("wikitech.wikimedia.org"),
+domain("otrs-wiki.wikimedia.org"),
+domain("commons.wikimedia.org"),
+domain("meta.wikimedia.org"),
+domain("species.wikimedia.org"),
 domain("wiktionary.org"),
+domain("wikivoyage.org"),
+domain("wikiversity.org"),
+domain("wikinews.org"),
+domain("wikiquote.org"),
+domain("wikisource.org"),
+domain("wikibooks.org"),
 domain("wiki.rpcs3.net") {
   /* Modified from https://userstyles.org/styles/47161/dark-wikipedia-rounded */
   :root {


### PR DESCRIPTION
Adds all the other Wikimedia projects that were missing, plus explicitly specify the *.wikimedia.org wikis without accidentally applying to non-wiki sites (e.g. ticket.wikimedia.org).