### PR TITLE
Color the image titles properly

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -231,7 +231,7 @@ regexp("https?:\/\/wiki\.(rpcs3\.net|(archlinux|mozilla)\.(org|jp))\/.*$") {
   .tfa-recent, #contentSub, #contentSub2, .central-featured-lang .link-box small,
   .central-featured-lang .link-box small, .other-project-tagline,
   .mw-number-text, .tux-editor-header, .tux-breadcrumb,
-  .ext-translate-language-selector-label {
+  .ext-translate-language-selector-label, .mw-mmv-title {
     color: var(--gray-a);
   }
   body, h1, h2, h3, h4, h5, h6, #footer li,


### PR DESCRIPTION
Goes from looking like 

![wiki-broken](https://user-images.githubusercontent.com/1731430/73005949-0e8b0700-3dc7-11ea-8a15-d4d76c082c37.png)

to

![wiki-fixed](https://user-images.githubusercontent.com/1731430/73005953-121e8e00-3dc7-11ea-8555-916125896740.png)

