### PR TITLE
Remove link for rpcs3.net

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -167,7 +167,7 @@ regexp("https?:\/\/.*wik(i|t).*(org|jp).*") {
 }
 @-moz-document
 regexp("https?:\/\/(([\w\-]{2,}\.)?(wiki(pedia|books|news|quote|source|versity|voyage)|wiktionary)|(www|test)\.(mediawiki|wiki(data|dot))|(meta|wikimania|commons|otrs-wiki|species|wikitech|incubator|outreach|foundation|donate)\.wikimedia)\.org\/.*"),
-regexp("https?:\/\/wiki\.((archlinux|mozilla)\.(org|jp))\/.*$") {
+regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   /* transparent background */
   html, body {
     background-color: var(--gray-2);

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -167,7 +167,7 @@ regexp("https?:\/\/.*wik(i|t).*(org|jp).*") {
 }
 @-moz-document
 regexp("https?:\/\/(([\w\-]{2,}\.)?(wiki(pedia|books|news|quote|source|versity|voyage)|wiktionary)|(www|test)\.(mediawiki|wiki(data|dot))|(meta|wikimania|commons|otrs-wiki|species|wikitech|incubator|outreach|foundation|donate)\.wikimedia)\.org\/.*"),
-regexp("https?:\/\/wiki\.(rpcs3\.net|(archlinux|mozilla)\.(org|jp))\/.*$") {
+regexp("https?:\/\/wiki\.((archlinux|mozilla)\.(org|jp))\/.*$") {
   /* transparent background */
   html, body {
     background-color: var(--gray-2);


### PR DESCRIPTION
RPCS3 wiki now uses timeless theme by default, so having this theme enabled by default causes problems with the theme. If any user wishes to switch back to Vector, they can manually add this section back.