### PR TITLE
Fixes with weather tables

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -480,7 +480,7 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   td[style*="color:#000"]:not([style^="background"]), div[style*="color:black"],
   td[style*="color:darkslategray;"], .mw-mmv-post-image,
   .mw-mmv-permission-box .mw-mmv-permission-text, span[style*="color:#555555"], td[style^="background: #FFFFFF" i],
-  td[style^="background: #F5F" i] {
+  td[style^="background:#FFFFFF" i], td[style^="background: #F5F" i], td[style^="background:#F5F" i] {
     color: var(--gray-c) !important;
   }
   a, .CategoryTreeToggle, #toc a, #toc a span, body .ui-button, .toctogglelabel,

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -476,10 +476,11 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   a[href*="Wikipedia:Wikipedia_Signpost"] span, .vertical-navbox th span,
   span[style*="white-space:nowrap; line-height:120%; font-size:155%; color:#333;"],
   tr[style^="color:black"], span[title="To be announced"],
-  div[style*="color: black;"], td[style*="color: #000000;"],
-  td[style*="color:#000"], div[style*="color:black"],
+  div[style*="color: black;"], td[style*="color: #000000;"]:not([style^="background"]),
+  td[style*="color:#000"]:not([style^="background"]), div[style*="color:black"],
   td[style*="color:darkslategray;"], .mw-mmv-post-image,
-  .mw-mmv-permission-box .mw-mmv-permission-text, span[style*="color:#555555"] {
+  .mw-mmv-permission-box .mw-mmv-permission-text, span[style*="color:#555555"], td[style^="background: #FFFFFF" i],
+  td[style^="background: #F5F" i] {
     color: var(--gray-c) !important;
   }
   a, .CategoryTreeToggle, #toc a, #toc a span, body .ui-button, .toctogglelabel,

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1090,7 +1090,7 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
     color: var(--gray-c);
   }
   table.wikitable > tr > th,
-  table.wikitable > * > tr > th:not([style*="#ABC;"]):not([style*="#fdb"]):not([style*="#fed"]):not([style*="#fef"]):not([style*="#d4f"]),
+  table.wikitable > * > tr > th:not([style*="#ABC;"]):not([style*="#fdb"]):not([style*="#fed"]):not([style*="#fef"]):not([style*="#d4f"]):not([style*="0; color:#000000"]):not([style*="FF; color:#000000"]),
   td[style*="background: #ececec;" i], th[style*="background:#eee" i],
   th[style*="background-color: #eee" i], tr[style*="background: #dddddd" i],
   tr[style*="background-color: #f7f7f7;" i], th[style*="background:#F2F2F2" i],


### PR DESCRIPTION
Fixed light gray text on light background in various weather tables. 

Example 1:
Before: ![](https://i.imgur.com/TkMnbG3.png)
After: ![](https://i.imgur.com/hfhBTfr.png)

Example 2:
Before: ![](https://i.imgur.com/LAYHSdn.png)
After: ![](https://i.imgur.com/4UFpGew.png)

Fixed issue with dark color and dark background on Russian version of Wikipedia
Before: ![](https://i.imgur.com/NlDqujY.png)
After: ![](https://i.imgur.com/GbWJcX4.png)

I hope this it will be enough. The color of these tables should be more unified...