### PR TITLE
Miscellaneous white background fixes

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1276,8 +1276,10 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   .messagebox, .errorbox, .warningbox, .successbox,
   .suggestions-special .special-label, .reference-text,
   .mwe-popups .mwe-popups-container, #viewsourcetext {
-    background-color: var(--gray-2) !important;
     color: var(--gray-c);
+  }
+  .mwe-popups .mwe-popups-container {
+    background-color: var(--gray-2) !important;
   }
   .mwe-popups .mwe-popups-container .mwe-popups-discreet {
     background-color: var(--white) !important;
@@ -4191,6 +4193,26 @@ regexp("https?:\/\/([\w\-]{2,}\.m\.(wiki(pedia|books|news|quote|source|versity|v
   }
   tr[bgcolor], td[bgcolor] {
     background-color: var(--gray-28);
+  }
+  /* popups fixes */
+  .mwe-popups .mwe-popups-container {
+    background-color: var(--gray-2) !important;
+  }
+  .mwe-popups .mwe-popups-container .mwe-popups-discreet {
+    background-color: var(--white) !important;
+  }
+  .mwe-popups .mwe-popups-container a {
+    color: var(--gray-c) !important;
+  }
+  .mwe-popups-extract::after {
+    background-image: linear-gradient(to right, transparent, var(--gray-2) 50%) !important;
+  }
+  .mw-mmv-ttf-ellipsis::before {
+    background-image: linear-gradient(to right, transparent, var(--gray-2)) !important;
+  }
+  .mwe-popups-extract .mwe-popups-fade,
+  .mw-mmv-permission-box .mw-mmv-permission-text .mw-mmv-permission-text-fader {
+    background-image: linear-gradient(to bottom, transparent, var(--gray-2)) !important;
   }
   /* these general selectorss have to go when adding not remove all */
   td[style*="background"] {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -2853,6 +2853,7 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   .mw-echo-ui-notificationBadgeButtonPopupWidget-popup > .oo-ui-popupWidget-popup > .oo-ui-popupWidget-head,
   .mw-echo-ui-notificationItemWidget:last-child {
     border-color: var(--gray-5);
+    background-color: var(--gray-2);
   }
   body[class*="skin-"] .mw-parser-output table.ambox {
     border: 1px solid var(--gray-5);

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -4053,6 +4053,9 @@ regexp("https?:\/\/([\w\-]{2,}\.m\.(wiki(pedia|books|news|quote|source|versity|v
     background-color: var(--blue-3);
     border-color: var(--blue-4);
   }
+  .lazy-image-placeholder {
+    background-color: var(--gray-28)
+  }
   /* Search */
   .client-nojs .search-box .search:focus,
   .search-overlay .search-box .search:focus {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1281,7 +1281,7 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   .mwe-popups .mwe-popups-container {
     background-color: var(--gray-2) !important;
   }
-  .mwe-popups .mwe-popups-container .mwe-popups-discreet {
+  .mwe-popups .mwe-popups-container .mwe-popups-thumbnail {
     background-color: var(--white) !important;
   }
   span[style="color:black"], span[style*="color: black"],
@@ -4198,7 +4198,7 @@ regexp("https?:\/\/([\w\-]{2,}\.m\.(wiki(pedia|books|news|quote|source|versity|v
   .mwe-popups .mwe-popups-container {
     background-color: var(--gray-2) !important;
   }
-  .mwe-popups .mwe-popups-container .mwe-popups-discreet {
+  .mwe-popups .mwe-popups-container .mwe-popups-thumbnail {
     background-color: var(--white) !important;
   }
   .mwe-popups .mwe-popups-container a {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -2849,7 +2849,6 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   .mw-echo-ui-notificationBadgeButtonPopupWidget-popup > .oo-ui-popupWidget-popup > .oo-ui-popupWidget-head,
   .mw-echo-ui-notificationItemWidget:last-child {
     border-color: var(--gray-5);
-    background-color: var(--gray-2);
   }
   body[class*="skin-"] .mw-parser-output table.ambox {
     border: 1px solid var(--gray-5);
@@ -2859,6 +2858,9 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   }
   table.ambox-protection {
     border-left: 10px solid var(--gray-7) !important;
+  }
+  table.sidebar.vertical-navbox.nomobile {
+    background-color: var(--gray-2);
   }
   /* these are OK to be !important soon as a not is needed remove the offending one instead and fix fallback */
   #talkheader td, .infobox tr[style*="background-color"]:not([style*="#cedff2"]),

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -4029,6 +4029,9 @@ regexp("https?:\/\/([\w\-]{2,}\.m\.(wiki(pedia|books|news|quote|source|versity|v
     background: var(--gray-28);
     border-color: var(--gray-5);
   }
+  .mw-parser-output .quotebox {
+    background: var(--gray-2)
+  }
   #mp-middle p, #mp-other-lower p {
     color: var(--gray-c);
   }

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1974,10 +1974,6 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   td[style*="background: #F5F5FF"] {
     background-color: var(--gray-28) !important;
   }
-  html .thumbimage {
-    background-color: var(--gray-28);
-    border-color: var(--gray-5);
-  }
   .oo-ui-menuSelectWidget {
     background-color: var(--gray-18);
     border-color: var(--gray-5);
@@ -4200,6 +4196,9 @@ regexp("https?:\/\/([\w\-]{2,}\.m\.(wiki(pedia|books|news|quote|source|versity|v
   }
   tr[bgcolor], td[bgcolor] {
     background-color: var(--gray-28);
+  }
+  html .thumbimage {
+    background-color: var(--white);
   }
   /* popups fixes */
   .mwe-popups .mwe-popups-container {


### PR DESCRIPTION
This is to fix several more issues with white background. All examples are taken from the page https://en.wikipedia.org/wiki/Riemann_hypothesis

- Commit https://github.com/StylishThemes/Wikipedia-Dark/commit/8304d001544a6600daa7e589ac7f038b5842b12e fixes white background for tables on desktop

    ![image](https://user-images.githubusercontent.com/3488460/106012096-a95ea580-60ed-11eb-88ac-ed9f127e55e9.png)

- Commit https://github.com/StylishThemes/Wikipedia-Dark/commit/335aebb4d50056455c16b6be763ef65e185140c8 fixes white background on mobile quotebox

    ![White Quotebox](https://user-images.githubusercontent.com/3488460/106012687-39045400-60ee-11eb-8d74-97c3b5c986e2.jpg)

- Commit https://github.com/StylishThemes/Wikipedia-Dark/commit/958f8117fdafded492ed7540b6e5a71419f16006 fixes white background on mobile lazy loading placeholder image

    ![White Lazy](https://user-images.githubusercontent.com/3488460/106012989-96000a00-60ee-11eb-8207-84f8c0adcaf7.jpg)

- Commit https://github.com/StylishThemes/Wikipedia-Dark/commit/e04f567f362d6a8e7f551e516b47acee2d4b9587 is to remove redundant style (has been mentioned on line 2870 of the code). In addition, background color for mobile is also adjusted so that texts on svg image displays correctly
