### PR TITLE
Fix contrast issue with conjugation tables in wiktionary

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -98,6 +98,7 @@ regexp("https?:\/\/.*wik(i|t).*(org|jp).*") {
     --brown-4: #4b380d;
     --yellow-1: #b28200;
     --yellow-2: #ffdd7f;
+    --yellow-3: #a88b2c;
     --orange-1: #e53e00;
     --orange-2: #e08b26;
     --purple-d: #241738;
@@ -6546,8 +6547,48 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   .list-switcher-element a[role="button"] {
     color: var(--base-color) !important;
   }
-  .NavContent > table > tbody > tr > th {
-    color: var(--gray-5);
+  tr > *[style*="background:#c0cfe4"],
+  tr > *[style*="background:#9999DF"] {
+    background-color: var(--blue-4) !important;
+  }
+  tr > *[style*="background:#a0ade3"],
+  tr > *[style*="background:#ccccff"] {
+    background-color: var(--blue-3) !important;
+  }
+  tr > *[style*="background:#e2e4c0"],
+  tr > *[style*="background:#d0cfa4"] {
+    background-color: var(--yellow-1) !important;
+  }
+  tr > *[style*="background:#c0d8e4"] {
+    background-color: var(--yellow-3) !important;
+  }
+  tr > *[style*="background:#e0e0b0"] {
+    background-color: var(--pink-1) !important;
+  }
+  tr > *[style*="background:#c0e4c0"],
+  tr > *[style*="background:#99cc99"],
+  tr > *[style*="background:#99CC99"] {
+    background-color: var(--green-3) !important;
+  }
+  tr > *[style*="background:#cfedcc"] {
+    background-color: var(--green-4) !important;
+  }
+  tr > *[style*="background:#e4d4c0"],
+  tr > *[style*="background:#f2caa4"] {
+    background-color: var(--red-3) !important;
+  }
+  tr > *[style*="background:#ECECEC"],
+  tr > *[style*="background:#C0C0C0"],
+  tr > *[style*="background:#d0d0d0"],
+  tr > *[style*="background:#EFEFEF"],
+  tr > *[style*="background: rgb(204, 204, 204)"],
+  tr > *[style*="background: #CCC"] {
+    background-color: var(--gray-4) !important;
+  }
+  div[style*="background:#d9ebff"],
+  tr > *[style*="background:#e0e0e0"],
+  tr > *[style*="background:#DEDEDE"]  {
+    background-color: var(--gray-3) !important;
   }
   .HQToggle::before, .NavToggle::before, .HQToggle::after, .NavToggle::after {
     color: var(--base-color);

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -6552,17 +6552,19 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
     background-color: var(--blue-4) !important;
   }
   *[style*="background:#a0ade3"],
-  *[style*="background:#ccccff"] {
-    background-color: var(--blue-3) !important;
-  }
-  *[style*="background:#e2e4c0"],
-  *[style*="background:#d0cfa4"] {
-    background-color: var(--brown-2) !important;
-  }
+  *[style*="background:#ccccff"],
+  *[style*="background: rgb(242, 242, 255)"],
+  *[style*="background:#ccd8ff"],
   *[style*="background:#c0d8e4"] {
     background-color: var(--blue-3) !important;
   }
-  *[style*="background:#e0e0b0"] {
+  *[style*="background:#e2e4c0"],
+  *[style*="background-color:#e2e4c0"],
+  *[style*="background:#d0cfa4"] {
+    background-color: var(--brown-2) !important;
+  }
+  *[style*="background:#e0e0b0"],
+  *[style*="background:#e2c0c0"] {
     background-color: var(--pink-1) !important;
   }
   *[style*="background:#c0e4c0"],
@@ -6579,16 +6581,23 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   }
   *[style*="background:#ECECEC"],
   *[style*="background:#C0C0C0"],
+  *[style*="background-color:#C0C0C0"],
   *[style*="background:#d0d0d0"],
   *[style*="background:#EFEFEF"],
   *[style*="background: rgb(204, 204, 204)"],
+  *[style*="background:#e2f6e2"],
+  *[style*="background: #e2f6e2"],
   *[style*="background: #CCC"] {
     background-color: var(--gray-4) !important;
   }
   div[style*="background:#d9ebff"],
+  div.CategoryTreeItem,
   *[style*="background:#e0e0e0"],
   *[style*="background:#DEDEDE"]  {
     background-color: var(--gray-3) !important;
+  }
+  table.inflection-table[style*="color: rgb(0%,0%,30%)"] {
+    color: var(--gray-c) !important;
   }
   .HQToggle::before, .NavToggle::before, .HQToggle::after, .NavToggle::after {
     color: var(--base-color);

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -100,6 +100,7 @@ regexp("https?:\/\/.*wik(i|t).*(org|jp).*") {
     --yellow-2: #ffdd7f;
     --orange-1: #e53e00;
     --orange-2: #e08b26;
+    --orange-3: #4d2b01;
     --purple-d: #241738;
     --purple-0: #312641;
     --purple-1: #382b4a;
@@ -6574,7 +6575,7 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   }
   *[style*="background:#e4d4c0"],
   *[style*="background:#f2caa4"] {
-    background-color: var(--red-3) !important;
+    background-color: var(--orange-3) !important;
   }
   *[style*="background:#ECECEC"],
   *[style*="background:#C0C0C0"],

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -98,7 +98,6 @@ regexp("https?:\/\/.*wik(i|t).*(org|jp).*") {
     --brown-4: #4b380d;
     --yellow-1: #b28200;
     --yellow-2: #ffdd7f;
-    --yellow-3: #a88b2c;
     --orange-1: #e53e00;
     --orange-2: #e08b26;
     --purple-d: #241738;
@@ -6560,7 +6559,7 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
     background-color: var(--yellow-1) !important;
   }
   tr > *[style*="background:#c0d8e4"] {
-    background-color: var(--yellow-3) !important;
+    background-color: var(--blue-3) !important;
   }
   tr > *[style*="background:#e0e0b0"] {
     background-color: var(--pink-1) !important;

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -6546,6 +6546,9 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   .list-switcher-element a[role="button"] {
     color: var(--base-color) !important;
   }
+  .NavContent > table > tbody > tr > th {
+    color: var(--gray-5);
+  }
   .HQToggle::before, .NavToggle::before, .HQToggle::after, .NavToggle::after {
     color: var(--base-color);
   }

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -6546,47 +6546,47 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   .list-switcher-element a[role="button"] {
     color: var(--base-color) !important;
   }
-  tr > *[style*="background:#c0cfe4"],
-  tr > *[style*="background:#9999DF"] {
+  *[style*="background:#c0cfe4"],
+  *[style*="background:#9999DF"] {
     background-color: var(--blue-4) !important;
   }
-  tr > *[style*="background:#a0ade3"],
-  tr > *[style*="background:#ccccff"] {
+  *[style*="background:#a0ade3"],
+  *[style*="background:#ccccff"] {
     background-color: var(--blue-3) !important;
   }
-  tr > *[style*="background:#e2e4c0"],
-  tr > *[style*="background:#d0cfa4"] {
+  *[style*="background:#e2e4c0"],
+  *[style*="background:#d0cfa4"] {
     background-color: var(--yellow-1) !important;
   }
-  tr > *[style*="background:#c0d8e4"] {
+  *[style*="background:#c0d8e4"] {
     background-color: var(--blue-3) !important;
   }
-  tr > *[style*="background:#e0e0b0"] {
+  *[style*="background:#e0e0b0"] {
     background-color: var(--pink-1) !important;
   }
-  tr > *[style*="background:#c0e4c0"],
-  tr > *[style*="background:#99cc99"],
-  tr > *[style*="background:#99CC99"] {
+  *[style*="background:#c0e4c0"],
+  *[style*="background:#99cc99"],
+  *[style*="background:#99CC99"] {
     background-color: var(--green-3) !important;
   }
-  tr > *[style*="background:#cfedcc"] {
+  *[style*="background:#cfedcc"] {
     background-color: var(--green-4) !important;
   }
-  tr > *[style*="background:#e4d4c0"],
-  tr > *[style*="background:#f2caa4"] {
+  *[style*="background:#e4d4c0"],
+  *[style*="background:#f2caa4"] {
     background-color: var(--red-3) !important;
   }
-  tr > *[style*="background:#ECECEC"],
-  tr > *[style*="background:#C0C0C0"],
-  tr > *[style*="background:#d0d0d0"],
-  tr > *[style*="background:#EFEFEF"],
-  tr > *[style*="background: rgb(204, 204, 204)"],
-  tr > *[style*="background: #CCC"] {
+  *[style*="background:#ECECEC"],
+  *[style*="background:#C0C0C0"],
+  *[style*="background:#d0d0d0"],
+  *[style*="background:#EFEFEF"],
+  *[style*="background: rgb(204, 204, 204)"],
+  *[style*="background: #CCC"] {
     background-color: var(--gray-4) !important;
   }
   div[style*="background:#d9ebff"],
-  tr > *[style*="background:#e0e0e0"],
-  tr > *[style*="background:#DEDEDE"]  {
+  *[style*="background:#e0e0e0"],
+  *[style*="background:#DEDEDE"]  {
     background-color: var(--gray-3) !important;
   }
   .HQToggle::before, .NavToggle::before, .HQToggle::after, .NavToggle::after {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -6556,7 +6556,7 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   }
   *[style*="background:#e2e4c0"],
   *[style*="background:#d0cfa4"] {
-    background-color: var(--yellow-1) !important;
+    background-color: var(--brown-2) !important;
   }
   *[style*="background:#c0d8e4"] {
     background-color: var(--blue-3) !important;


### PR DESCRIPTION
I found a problem with some tables on the wiktionary: the text is too light and unreadable. For instance on [this page](https://en.wiktionary.org/wiki/limpiar):

![Capture d’écran de 2021-03-09 09-08-34](https://user-images.githubusercontent.com/24524930/110441234-d2ddfa00-80b9-11eb-94b0-7a8645c3a81c.png)

With this PR it looks like so: 
![Capture d’écran de 2021-03-09 09-08-54](https://user-images.githubusercontent.com/24524930/110441252-d83b4480-80b9-11eb-885f-36c87184fe75.png)

Maybe a better solution would be to darken the background, but I don't know how to do that (the background is defined in a `style` attribute)