### PR TITLE
Fix Wiktionary backgrounds

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -5829,6 +5829,7 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
     color: var(--gray-a) !important;
   }
   .bandeau-simple.bandeau-niveau-information,
+  .bandeau-section.bandeau-niveau-information,
   .bandeau-discussion.bandeau-niveau-information {
     border-color: var(--blue-4) !important;
     background-color: var(--blue-2);

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -5704,7 +5704,7 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
     background: var(--blue-2);
     border-color: var(--blue-3);
   }
-  .cadre.vert, .cadre.vert h3 {
+  .cadre.vert, .cadre.vert h3, div.bandeau-voir {
     background: var(--green-4);
     border-color: var(--green-2);
   }

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -5555,7 +5555,7 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   div[style*="background-color:#EAF3FC"],
   table[style*="background-color:#F5FAFE"],
   td[style*="background-color: #F7F7F9"] {
-      background-color: transparent !important;
+    background-color: var(--gray-2_75) !important;
   }
   table[style*="background-color: #FCFCFC"] {
     background: var(--green-4) !important;

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -390,7 +390,7 @@ regexp("https?:\/\/(([\w\-]{2,}\.)?(wiki(pedia|books|news|quote|source|versity|v
 regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   /* transparent background */
   html, body, .mw-body[role="main"], .skin-vector-max-width .mw-page-container,
-  .skin-vector-max-width #mw-panel, .mw-page-container {
+  .skin-vector #mw-panel, .mw-page-container {
     background-color: var(--gray-2);
     background-image: var(--bg-selected);
     background-clip: border-box;

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -5547,6 +5547,21 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
     background: var(--brown-4) !important;
   }
 }
+@-moz-document domain("de.wiktionary.org") {
+  div.mw-parser-output h2, div.mw-parser-output h3 {
+    background-color: transparent !important;
+  }
+  div[style*="background-color: #EFF5FB"],
+  div[style*="background-color:#EAF3FC"],
+  table[style*="background-color:#F5FAFE"],
+  td[style*="background-color: #F7F7F9"] {
+      background-color: transparent !important;
+  }
+  table[style*="background-color: #FCFCFC"] {
+    background: var(--green-4) !important;
+    border-color: var(--green-2) !important;
+  }
+}
 @-moz-document domain("de.wikipedia.org") {
   img[src*="24px-OOjs_UI_icon_signature-ltr.svg"] {
     filter: invert(1) brightness(75%);


### PR DESCRIPTION
Fix some backgrounds on the wiktionary:
* the sidebar is white in the French wiktionary, also, the "see also" banner is too light
* In the german wiktionary, see eg [this page](https://de.wiktionary.org/wiki/Ungarisch), where some headers are whitish, and the translation table too (there are many shades of white in this table alone...)

Screens:
![Capture d’écran de 2021-03-15 20-57-07](https://user-images.githubusercontent.com/24524930/111213539-23c98300-85d1-11eb-9834-b5810ba7ff55.png)

![Capture d’écran de 2021-03-15 20-55-42](https://user-images.githubusercontent.com/24524930/111213343-f4b31180-85d0-11eb-8393-1bb870fe5732.png)

