### PR TITLE
Update wikipedia-dark.user.css

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -972,7 +972,7 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   select, textarea:not([class*="mw-editfont"]),
   tr[style*="background: antiquewhite" i]:not([style*="color: black" i]), #toc,
   td[style*="background-color"]:not([style*="F9"]):not([style*="FD"]):not([style*="FF"]):not([style*="CF"]):not([style*="fed"]):not([style*="F0F"]):not([style*="F9F"]):not([style*="D4F"]):not([style*="FDB"]):not([style*="FFF"]):not([style*="f4e"]):not([style*="faf"]):not([style*="f1f"]):not([style*="B0C4DE"]):not([style*="cdde"]):not([style*="8"]):not([style*="00"]):not([style*="FF6"]):not([style*="f2f2f4"]):not([style*="fc3"]):not([style*="E6F2FF"]):not([style*="ccccff"]):not([style*="f89b8f"]):not([style*="fba89d"]):not([style*="fecec8"]):not([style*="f68d81"]):not([style*="c1ccf2"]):not([style*="b8c4ef"]):not([style*="fcb5ab"]):not([style*="d33"]):not([style*="fec1b9"]):not([style*="fedbd7"]):not([style*="f0f0ff"]):not([style*="a8b4ea"]):not([style*="b1bced"]):not([style*="c9d4f5"]):not([style*="d2dbf7"]):not([style*="9fade8"]):not([style*="eaf3ff"]):not([style*="e2ebfc"]):not([style*="f8f8ff"]):not([style*="f8fff8"]):not([style*="ddddff"]):not([style*="eeeeff"]),
-  #mw-content-text div[style*="background:"]:not([style*="BF4"]):not([style*="468"]):not([style*="CED"]):not([style*="008"]):not([style*="ffe"]):not([style*="ffdb"]):not([style*="fafc"]):not([style*="ffe4"]):not([style*="3ff"]):not([style*="ffee"]):not([style*="bce1"]):not([style*="ebb"]):not([style*="EDD"]):not([style*="bff"]):not([style*="f7f7"]):not([style*="444"]):not([style*="fdf6e3"]):not([style*="CCF"]):not([style*="F9FCFF"]):not([style*="2a4b8d"]):not([style*="E0EEE0"]):not([style*="E8F1FF"]):not([style*="EEF"]):not([style*="7DC2F5"]):not([style*="CCC"]):not([style*="F16633"]):not([style*="F0F0FF"]):not([style*="336"]):not([style*="D33"]):not([style*="F0F8FF"]):not([style*="00AF89"]):not([style*="36C"]):not([style*="006699"]):not([style*="990000"]):not([style*="#e7eff5;"]):not([style*="#90EE90;"]):not([class*="-active"]):not([style*="#339966"]):not([style*="FFF"]):not([style*="2E0"]):not([style*="14866d"]):not([style*="transparent"]):not([style*="F5FAFF"]):not([style*="A3B1BF"]):not([style*="fff5fa"]):not([style*="faf5ff"]),
+  #mw-content-text div[style*="background:"]:not([style*="BF4"]):not([style*="468"]):not([style*="CED"]):not([style*="008"]):not([style*="ffe"]):not([style*="ffdb"]):not([style*="fafc"]):not([style*="ffe4"]):not([style*="3ff"]):not([style*="ffee"]):not([style*="bce1"]):not([style*="ebb"]):not([style*="EDD"]):not([style*="bff"]):not([style*="f7f7"]):not([style*="444"]):not([style*="fdf6e3"]):not([style*="CCF"]):not([style*="F9FCFF"]):not([style*="2a4b8d"]):not([style*="E0EEE0"]):not([style*="E8F1FF"]):not([style*="EEF"]):not([style*="7DC2F5"]):not([style*="CCC"]):not([style*="F16633"]):not([style*="F0F0FF"]):not([style*="336"]):not([style*="D33"]):not([style*="F0F8FF"]):not([style*="00AF89"]):not([style*="36C"]):not([style*="006699"]):not([style*="990000"]):not([style*="#e7eff5;"]):not([style*="#90EE90;"]):not([class*="-active"]):not([style*="#339966"]):not([style*="FFF"]):not([style*="2E0"]):not([style*="14866d"]):not([style*="transparent"]):not([style*="F5FAFF"]):not([style*="A3B1BF"]):not([style*="fff5fa"]):not([style*="faf5ff"]):not([style^="overflow:hidden;background:#e44"]),
   .vevent td:not(.fileinfo-paramfield), .referencetooltip li, .suggestions,
   .mw-ui-button[style*="background"]:not([style*="d33682"]):not([style*="6c71c4"]):not([style*="268bd2"]),
   .mw-ui-button[style*="background"] *, .wikiEditor-ui, .mw-search-results li,
@@ -3003,8 +3003,14 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
     background-color: var(--gray-2) !important;
     border-color: var(--gray-5) !important;
   }
-  li.gallerybox div.thumb {
-    background-color: var(--gray-18);
+  .mw-gallery-traditional li.gallerybox div.thumb {
+    background-color: var(--gray-18) !important;
+  }
+  th[style^="padding:2px; font-size:90%; background-color:#efefef;"] {
+    background-color: var(--gray-28) !important;
+  }
+  .infobox > tbody > tr[style*="background:#eee;"] {
+    background-color: var(--gray-2) !important;
   }
   tr.quality0 td {
     background-color: var(--gray-28) !important;
@@ -3669,7 +3675,9 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   }
   .cx-dashboard, .cx-slitem__details .cx-slitem__translation-link .source-title,
   .cx-tlitem .cx-tlitem__details .translation-link .source-title,
-  .cx-ui-translationIssue.oo-ui-tabPanelLayout > .cx-ui-translationIssue-message {
+  .cx-ui-translationIssue.oo-ui-tabPanelLayout > .cx-ui-translationIssue-message,
+  .cx-pagetitle.oo-ui-textInputWidget textarea,
+  .cx-translation-view-header .cx-header__translation-center .oo-ui-buttonElement-button .oo-ui-labelElement-label {
     color: var(--gray-c);
   }
   .cx-translationlist-container, .cx-translation-view, .cx-column,
@@ -3771,7 +3779,8 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   img[src*="C%C3%ADrculos_Conc%C3%A9ntricos.svg"],
   img[src*="Johnny-automatic-scales-of-justice"], img[src*="_scales"],
   a.image img[src*="Cross_country_skiing_pictogram"],
-  .ve-ui-educationPopup-header {
+  .ve-ui-educationPopup-header,
+  img[src*="/Status_iucn3."] {
     filter: invert(100%) hue-rotate(180deg) brightness(120%) contrast(102%);
   }
   a.image img[src*="Newspaper_Cover.svg"],
@@ -3935,6 +3944,9 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
   }
   #pt-uls a.uls-trigger, .sprite.svg-Wikimedia-logo_black {
     filter: invert(100%) hue-rotate(180deg);
+  }
+  .cx-header__personal a.uls-trigger:hover {
+    color: var(--gray-1) !important;
   }
   div#mw-panel div.portal .body {
     background-image: none !important;
@@ -5849,7 +5861,13 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   }
   figure[typeof~="mw:Image/Thumb"], figure[typeof~="mw:Video/Thumb"],
   figure[typeof~="mw:Audio/Thumb"], figure[typeof~="mw:Image/Frame"],
-  figure[typeof~="mw:Video/Frame"], figure[typeof~="mw:Audio/Frame"] {
+  figure[typeof~="mw:Video/Frame"], figure[typeof~="mw:Audio/Frame"],
+  figure[typeof~="mw:Image/Thumb"] > figcaption,
+  figure[typeof~="mw:Video/Thumb"] > figcaption,
+  figure[typeof~="mw:Audio/Thumb"] > figcaption,
+  figure[typeof~="mw:Image/Frame"] > figcaption,
+  figure[typeof~="mw:Video/Frame"] > figcaption,
+  figure[typeof~="mw:Audio/Frame"] > figcaption {
     border: 1px solid var(--gray-5);
     background-color: var(--gray-28);
   }

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -5862,11 +5862,6 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   figure[typeof~="mw:Image/Thumb"], figure[typeof~="mw:Video/Thumb"],
   figure[typeof~="mw:Audio/Thumb"], figure[typeof~="mw:Image/Frame"],
   figure[typeof~="mw:Video/Frame"], figure[typeof~="mw:Audio/Frame"],
-  figure[typeof~="mw:Image/Thumb"] > figcaption,
-  figure[typeof~="mw:Video/Thumb"] > figcaption,
-  figure[typeof~="mw:Audio/Thumb"] > figcaption,
-  figure[typeof~="mw:Image/Frame"] > figcaption,
-  figure[typeof~="mw:Video/Frame"] > figcaption,
   figure[typeof*="mw"] > figcaption {
     border: 1px solid var(--gray-5);
     background-color: var(--gray-28);

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -5867,7 +5867,7 @@ regexp("^https://(foundation|donate)\.wikimedia\.org.*$") {
   figure[typeof~="mw:Audio/Thumb"] > figcaption,
   figure[typeof~="mw:Image/Frame"] > figcaption,
   figure[typeof~="mw:Video/Frame"] > figcaption,
-  figure[typeof~="mw:Audio/Frame"] > figcaption {
+  figure[typeof*="mw"] > figcaption {
     border: 1px solid var(--gray-5);
     background-color: var(--gray-28);
   }


### PR DESCRIPTION
Fixed IUCN dark colour on dark background, white background behind some thumbnails in articles, translator tool fonts and others I forgot now where :)

Example:
![obraz](https://user-images.githubusercontent.com/34380553/112750565-9e2ed580-8fc9-11eb-98f8-020f31cfa85b.png)
