### PR TITLE
Removal of problematic code

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1314,26 +1314,6 @@ regexp("https?:\/\/wiki\.(archlinux|mozilla)\.(org|jp)\/.*$") {
     border-top: 1px solid var(--gray-4);
     color: var(--gray-c);
   }
-  table.wikitable > tr > th,
-  table.wikitable > * > tr > th:not([style*="#ABC;"]):not([style*="#fdb"]):not([style*="#fed"]):not([style*="#fef"]):not([style*="#d4f"]):not([style*="0; color:#000000"]):not([style*="FF; color:#000000"]),
-  td[style*="background: #ececec;" i], th[style*="background:#eee" i],
-  th[style*="background-color: #eee" i], tr[style*="background: #dddddd" i],
-  tr[style*="background-color: #f7f7f7;" i], th[style*="background:#F2F2F2" i],
-  #filetoc, th[style*="background:#F9F9F9" i],
-  th[style*="background-color: lightgrey" i], th[style*="background:#ddd" i],
-  .infobox th[style*="background"]:not([style*="green"]):not([style*="background:#dfc;"]):not(.infobox-above):not([style*="lavender"]):not([style*="cfe3ff"]):not([style*="rgb(235,235,210)"]):not([style*="antiquewhite"]),
-  .infobox tr[style*="background-color"]:not([style*="cedff2"]),
-  .infobox td[style*="background"]:not([style*="D8B"]):not([style*="cdde"]):not([style*="e8dbae"]):not([style*="FE4"]):not([style*="301"]):not([style*="722"]):not([style*="781"]):not([style*="702"]):not([style*="6C3"]):not([style*="880"]):not([style*="866"]):not([style*="512"]):not([style*="DE6"]):not([style*="C54"]):not([style*="B76"]):not([style*="9A4"]):not([style*="4E2"]):not([style*="DF0"]):not([style*="DA7"]):not([style*="DF7"]):not([style*="9F00"]):not([style*="FAE6"]):not([style*="E0B0"]):not([style*="800080"]):not([style*="66023C"]):not([style*="7851A9"]):not([style*="C71585"]):not([style*="BF00FF"]):not([style*="A020F0"]):not([style*="9370DB"]):not([style*="663399"]),
-  td[style*="background:#F2F2F2" i],
-  table.wikitable > tbody > tr[style*="background-color:#F6F6F6" i], .tlheader,
-  th[style*="background:whitesmoke" i], td[style*="background:whitesmoke" i],
-  th[style*="#FFEBAD" i], table.nmbox th:not([style*="#EEF"]),
-  tr[style*="#eaecf0" i], td[style*="#eaecf0" i],
-  p[style*="background-color:#F7FAFC" i],
-  .infobox.standard-talk tr[style*="#e8dbae"], th[style="background:lightgrey"],
-  div[style*="background-color: #dddddd" i] {
-    background-color: var(--gray-3) !important;
-  }
   .plainlinks.mw-trackedTemplate {
     background: var(--gray-3) !important;
   }


### PR DESCRIPTION
A segment of code is prohibiting custom colours from showing, which is problematic for when one wishes to see colour previews from the wiki's pages about colours. After reviewing the code segment in question, it appears like a cobbled-together mess that does not offer a lot of room for dynamic situations. If you wish to add back the sub-table grey, then I implore you to reconsider the coding logic before doing so.