### PR TITLE
new surface ui changes for english pages

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -547,6 +547,7 @@
   .mw-parser-output > div > blockquote > p,
   .mw-parser-output,
   .mw-echo-ui-menuItemWidget > .oo-ui-buttonElement-button > .oo-ui-labelElement-label,
+  .vector-user-menu-anon-editor,
   #pagehistory li.selected,
   #mwe-popups-settings main form label,
   #pt-anonuserpage,
@@ -833,6 +834,8 @@
   .uls-settings-trigger {
     border-color: var(--gray-2) !important;
   }
+  .vector-search-box-form #searchButton,
+  .vector-search-box-form #mw-searchButton,
   .wikibase-toolbar-container.wikibase-toolbar-container {
     background: transparent !important;
   }
@@ -854,6 +857,7 @@
   .RMinline[style*="background:#F9F9F9;"] {
     background-color: var(--gray-2) !important;
   }
+  .vector-dropdown > .vector-menu-content,
   .frb-inline-message,
   .frb-inline-main .cta-container {
     background-color: var(--gray-2);
@@ -1017,6 +1021,9 @@
     border: 1px solid var(--gray-5);
     background-color: var(--gray-3);
   }
+  .cdx-menu-item--enabled .cdx-menu-item__text__supporting-text,
+  .cdx-menu-item--enabled .cdx-menu-item__text__description,
+  .cdx-button:enabled,
   .oo-ui-menuOptionWidget.oo-ui-widget-enabled.oo-ui-optionWidget,
   .footer-sidebar-text,
   .site-license {
@@ -1236,6 +1243,67 @@
     background-color: var(--base-color);
     border-color: var(--base-color);
   }
+  .vector-user-menu-login {
+    border-bottom: 1px solid var(--gray-7);
+  }
+  .vector-feature-page-tools-disabled .vector-main-menu {
+    background-color: var(--black_17);
+  }
+  .vector-feature-page-tools-disabled .vector-main-menu-group .vector-menu-heading,
+  .vector-feature-page-tools-disabled .vector-main-menu-action-item .vector-menu-heading {
+    color: var(--gray-9a);
+    border-color: var(--gray-69);
+  }
+  .vector-search-box-form #searchButton {
+    background: no-repeat center / 1.23076923em url(/w/skins/Vector/resources/common/images/search.svg?ac00d) !important;
+  }
+  .vector-search-box-form input#searchButton[type="submit"] {
+    filter: invert(75%) !important;
+    border-left-color: var(--gray-a) !important;
+    background-color: transparent !important;
+    font-size: 1.23076923em;
+  }
+  .client-js .vector-search-box-vue .vector-typeahead-search .cdx-text-input__input:not(:hover):not(:focus) {
+    border-right-color: transparent !important;
+  }
+  .cdx-button--framed:enabled:hover {
+    background-color: var(--gray-a);
+    color: var(--gray-d);
+  }
+  .cdx-button--framed:enabled {
+    background-color: var(--gray-a);
+    border-color: var(--gray-5);
+  }
+  .cdx-menu {
+    background-color: var(--gray-2);
+    border: 1px solid var(--gray-4);
+  }
+  .cdx-menu-item--enabled:hover,
+  .cdx-menu-item--enabled.cdx-menu-item--highlighted {
+    background-color: var(--gray-5_25);
+  }
+  .cdx-thumbnail__placeholder,
+  .cdx-thumbnail__image {
+    border: 1px solid var(--gray-3);
+  }
+  .cdx-menu--has-footer .cdx-menu-item:last-of-type:not(:first-of-type) {
+    border-top: 1px solid var(--gray-3);
+  }
+  .mw-message-box {
+    color: var(--base-color);
+    background-color: var(--black_5);
+    border-color: var(--gray-3);
+  }
+  .cdx-menu-item--enabled.cdx-menu-item--active,
+  .cdx-menu-item--enabled.cdx-menu-item--active:hover {
+    background-color: var(--black_25);
+  }
+  .vector-page-titlebar {
+    box-shadow: 0 1px var(--gray-5);
+  }
+  .vector-page-toolbar-container {
+    box-shadow: 0 1px var(--gray-6_5);
+  }
   input#searchButton {
     border-left: 1px solid var(--gray-5) !important;
     border-top: 0 !important;
@@ -1283,6 +1351,8 @@
   .hatnote.navigation-not-searchable,
   .thumbcaption,
   .oo-ui-fieldLayout-disabled > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header > .oo-ui-labelElement-label,
+  .cdx-text-input__input:enabled:focus ~ .cdx-text-input__icon,
+  .cdx-text-input__input:enabled.cdx-text-input__input--has-value ~ .cdx-text-input__icon,
   #languagesettings-settings-panel {
     color: var(--gray-a);
   }
@@ -1445,7 +1515,7 @@
   td[style*="background:#eee" i],
   td[bgcolor="f5f5f5"],
   td > span[style*="background-color:#eee" i],
-  button:not([type="submit"]):not(.tux-editor-save-button):not(.save):not([class*="-settings-block"]):not([class*="mw-mmv-"]):not(.pure-button):not(.wikidialog-button):not(.uls-input-toggle-button),
+  button:not([type="submit"]):not(.tux-editor-save-button):not(.save):not([class*="-settings-block"]):not([class*="mw-mmv-"]):not(.pure-button):not(.wikidialog-button):not(.uls-input-toggle-button):not(.mw-ui-icon-wikimedia-expand),
   select,
   div.arcProg,
   textarea:not([class*="mw-editfont"]),
@@ -1476,6 +1546,7 @@
   .infoboks tr.rad td,
   .infoboks tr.bilde td,
   .infoboks tr.overskrift td,
+  .vector-unpinned-container .vector-toc,
   #mw-content-text :not(.color_swatch) > div[style*="background:"]:not([style*="BF4"]):not([style*="000"]):not([style*="468"]):not([style*="CED"]):not([style*="008"]):not([style*="ffe"]):not([style*="ffdb"]):not([style*="fafc"]):not([style*="ffe4"]):not([style*="3ff"]):not([style*="ffee"]):not([style*="bce1"]):not([style*="ebb"]):not([style*="EDD"]):not([style*="bff"]):not([style*="f7f7"]):not([style*="444"]):not([style*="fdf6e3"]):not([style*="CCF"]):not([style*="F9FCFF"]):not([style*="2a4b8d"]):not([style*="E0EEE0"]):not([style*="E8F1FF"]):not([style*="EEF"]):not([style*="7DC2F5"]):not([style*="CCC"]):not([style*="F16633"]):not([style*="F0F0FF"]):not([style*="336"]):not([style*="D33"]):not([style*="F0F8FF"]):not([style*="00AF89"]):not([style*="36C"]):not([style*="006699"]):not([style*="990000"]):not([style*="#e7eff5;"]):not([style*="#90EE90;"]):not([class*="-active"]):not([style*="#339966"]):not([style*="FFF"]):not([style*="2E0"]):not([style*="14866d"]):not([style*="transparent"]):not([style*="F5FAFF"]):not([style*="A3B1BF"]):not([style*="fff5fa"]):not([style*="faf5ff"]):not([style^="overflow:hidden;background:#e44"]):not([style*="width"]):not([style*="height"]):not([style*="bottom"]):not([style*="opacity"]),
   #toc,
   #mwe-popups-settings,
@@ -1491,6 +1562,8 @@
   #advancedSearchField-hastemplate {
     background-color: var(--gray-1) !important;
   }
+  .vector-toc-pinned #vector-toc-pinned-container .vector-toc::after,
+  .vector-toc-pinned #vector-toc-pinned-container .sidebar-toc::after,
   .mw-parser-output table.floatright[width="35%"] {
     background: none;
   }
@@ -1634,6 +1707,7 @@
   .client-js .mw-ui-radio:not(#noop) [type="radio"]:enabled:checked + label::before {
     border-color: var(--base-color);
   }
+  .cdx-search-input--has-end-button,
   .client-js .mw-ui-radio:not(#noop) [type="radio"] + label::before {
     background-color: var(--gray-1);
     border: 1px solid var(--gray-4);
@@ -1736,12 +1810,15 @@
   }
   img[src*="76px-Wikimedia_Research_Newsletter_Logo.png"],
   img[src*="OOjs_UI_icon_download-ltr-progressive.svg.png"],
+  .mw-ui-icon-wikimedia-logIn::before,
+  .mw-ui-icon-wikimedia-language::before,
   .mw-rcfilters-ui-filterWrapperWidget-showNewChanges .oo-ui-iconElement-icon {
     filter: invert(100%) hue-rotate(180deg);
   }
   div[style="float:right; border:1px solid #CCC"] {
     border-color: var(--gray-2) !important;
   }
+  .mw-logo-container > img,
   a img[src*="WRN_header.png"] {
     filter: invert(88%);
   }
@@ -1915,6 +1992,7 @@
     background-color: transparent !important;
     border: none !important;
   }
+  .vector-pinned-container .vector-toc,
   .mw-rcfilters-ui-filterMenuHeaderWidget-header,
   .mw-rcfilters-ui-menuSelectWidget-footer,
   .oo-ui-tagMultiselectWidget.oo-ui-widget-enabled .oo-ui-tagMultiselectWidget-handle,
@@ -3502,6 +3580,7 @@
   }
   /*** Border ***/
   /* default in some pages is different like 0, but transparent covers more than one case */
+  .vector-pinnable-header-toggle-button,
   .oo-ui-buttonElement-frameless.oo-ui-iconElement > .oo-ui-buttonElement-button,
   .oo-ui-buttonElement-frameless.oo-ui-labelElement > .oo-ui-buttonElement-button,
   .navbox-list {
@@ -3659,6 +3738,7 @@
   .infobox_v2,
   .mw-echo-ui-notificationBadgeButtonPopupWidget-popup > .oo-ui-popupWidget-popup > .oo-ui-popupWidget-head,
   .mw-echo-ui-notificationItemWidget:last-child,
+  .vector-menu-content,
   #specialchars,
   #content,
   #filetoc,
@@ -3791,6 +3871,8 @@
   .mw-datatable td,
   .mw-datatable th,
   .tux-action-bar button,
+  .vector-unpinned-container > #vector-toc,
+  .vector-menu-content,
   #talkheader td,
   #mwe-popups-settings,
   #mwe-popups-settings header {
@@ -4964,6 +5046,8 @@
   img[src*="Sort_both_small.svg"] {
     filter: invert(.8);
   }
+  .sidebar-toc .mw-ui-icon-wikimedia-expand::before,
+  .vector-toc .mw-ui-icon-wikimedia-expand::before,
   .oo-ui-indicator-down,
   .oo-ui-indicator-clear {
     filter: invert(100%);

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -837,8 +837,8 @@
   .uls-settings-trigger {
     border-color: var(--gray-2) !important;
   }
-  .vector-search-box-form #searchButton,
-  .vector-search-box-form #mw-searchButton,
+  .vector-search-box-collapses #searchButton,
+  .vector-search-box-collapses #mw-searchButton,
   .wikibase-toolbar-container.wikibase-toolbar-container {
     background: transparent !important;
   }
@@ -1261,10 +1261,10 @@
   .vector-search-box-input {
     padding: 5px 3.64615385em 5px 0.4em;
   }
-  .vector-search-box-form #searchButton {
+  .vector-search-box-collapses #searchButton {
     background: no-repeat center / 20px auto url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath d='M12.2 13.6a7 7 0 1 1 1.4-1.4l5.4 5.4-1.4 1.4zM3 8a5 5 0 1 0 10 0A5 5 0 0 0 3 8z'/%3E%3C/svg%3E") !important;
   }
-  .vector-search-box-form input#searchButton[type="submit"] {
+  .vector-search-box-collapses input#searchButton[type="submit"] {
     filter: invert(75%) !important;
     border-left-color: var(--gray-a) !important;
     background-color: transparent !important;

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -168,6 +168,9 @@
     --cm-13: #ff6400;
     --cm-14: #aeaeae;
     --cm-15: #ad9361;
+    /* Browser specifics */
+    scrollbar-color: #7779 #111111a3; /* firefox scrollbars */
+    color-scheme: dark; /* chrome scrollbars  */
   }
   .cm-comment,
   .cm-link {
@@ -1254,6 +1257,9 @@
   .vector-feature-page-tools-disabled .vector-main-menu-action-item .vector-menu-heading {
     color: var(--gray-9a);
     border-color: var(--gray-69);
+  }
+  .vector-search-box-input {
+    padding: 5px 3.64615385em 5px 0.4em;
   }
   .vector-search-box-form #searchButton {
     background: no-repeat center / 1.23076923em url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath d='M12.2 13.6a7 7 0 1 1 1.4-1.4l5.4 5.4-1.4 1.4zM3 8a5 5 0 1 0 10 0A5 5 0 0 0 3 8z'/%3E%3C/svg%3E") !important;

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1256,7 +1256,7 @@
     border-color: var(--gray-69);
   }
   .vector-search-box-form #searchButton {
-    background: no-repeat center / 1.23076923em url(/w/skins/Vector/resources/common/images/search.svg?ac00d) !important;
+    background: no-repeat center / 1.23076923em url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath d='M12.2 13.6a7 7 0 1 1 1.4-1.4l5.4 5.4-1.4 1.4zM3 8a5 5 0 1 0 10 0A5 5 0 0 0 3 8z'/%3E%3C/svg%3E") !important;
   }
   .vector-search-box-form input#searchButton[type="submit"] {
     filter: invert(75%) !important;

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1262,13 +1262,12 @@
     padding: 5px 3.64615385em 5px 0.4em;
   }
   .vector-search-box-form #searchButton {
-    background: no-repeat center / 1.23076923em url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath d='M12.2 13.6a7 7 0 1 1 1.4-1.4l5.4 5.4-1.4 1.4zM3 8a5 5 0 1 0 10 0A5 5 0 0 0 3 8z'/%3E%3C/svg%3E") !important;
+    background: no-repeat center / 20px auto url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath d='M12.2 13.6a7 7 0 1 1 1.4-1.4l5.4 5.4-1.4 1.4zM3 8a5 5 0 1 0 10 0A5 5 0 0 0 3 8z'/%3E%3C/svg%3E") !important;
   }
   .vector-search-box-form input#searchButton[type="submit"] {
     filter: invert(75%) !important;
     border-left-color: var(--gray-a) !important;
     background-color: transparent !important;
-    font-size: 1.23076923em;
   }
   .client-js .vector-search-box-vue .vector-typeahead-search .cdx-text-input__input:not(:hover):not(:focus) {
     border-right-color: transparent !important;

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1246,7 +1246,8 @@
   .vector-user-menu-login {
     border-bottom: 1px solid var(--gray-7);
   }
-  .vector-feature-page-tools-disabled .vector-main-menu {
+  .vector-feature-page-tools-disabled .vector-main-menu,
+  .vector-pinned-container .vector-toc {
     background-color: var(--black_17);
   }
   .vector-feature-page-tools-disabled .vector-main-menu-group .vector-menu-heading,
@@ -1515,7 +1516,7 @@
   td[style*="background:#eee" i],
   td[bgcolor="f5f5f5"],
   td > span[style*="background-color:#eee" i],
-  button:not([type="submit"]):not(.tux-editor-save-button):not(.save):not([class*="-settings-block"]):not([class*="mw-mmv-"]):not(.pure-button):not(.wikidialog-button):not(.uls-input-toggle-button):not(.mw-ui-icon-wikimedia-expand),
+  button:not([type="submit"]):not(.tux-editor-save-button):not(.save):not([class*="-settings-block"]):not([class*="mw-mmv-"]):not(.pure-button):not(.wikidialog-button):not(.uls-input-toggle-button):not(.mw-ui-icon-wikimedia-expand):not(.vector-pinnable-header-toggle-button),
   select,
   div.arcProg,
   textarea:not([class*="mw-editfont"]),
@@ -1992,7 +1993,6 @@
     background-color: transparent !important;
     border: none !important;
   }
-  .vector-pinned-container .vector-toc,
   .mw-rcfilters-ui-filterMenuHeaderWidget-header,
   .mw-rcfilters-ui-menuSelectWidget-footer,
   .oo-ui-tagMultiselectWidget.oo-ui-widget-enabled .oo-ui-tagMultiselectWidget-handle,

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1713,6 +1713,7 @@
   .client-js .mw-ui-radio:not(#noop) [type="radio"]:enabled:checked + label::before {
     border-color: var(--base-color);
   }
+  .client-js .vector-below-page-title .vector-page-titlebar-toc,
   .cdx-search-input--has-end-button,
   .client-js .mw-ui-radio:not(#noop) [type="radio"] + label::before {
     background-color: var(--gray-1);
@@ -1829,6 +1830,7 @@
     filter: invert(88%);
   }
   kbd,
+  .client-js .vector-below-page-title .vector-page-titlebar-toc,
   .keyboard-key {
     box-shadow: .1em .2em .2em var(--gray-4) !important;
   }


### PR DESCRIPTION
my first pull req
(somewhat) fixes #200 

targets:
- text logo
- main sidebar
- article toc + sidebar
- search bar
- search bar results

also made a few other icons brighter

open for suggestions as usual

preview: 
![image](https://user-images.githubusercontent.com/36298836/213466692-54d3a624-9055-450d-8e9b-882488a9c4fb.png)
![image](https://user-images.githubusercontent.com/36298836/213463930-0e874bac-caa9-49ac-8191-c74801fda725.png)

(sorry for the personal configured text colors)
