### PR TITLE
Update wikipedia-dark.user.css

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name         Wikipedia Dark
 @namespace    StylishThemes
-@version      3.7.2
+@version      3.7.3
 @description  Wikipedia Dark theme
 @author       StylishThemes
 @homepageURL  https://github.com/StylishThemes/Wikipedia-Dark
@@ -447,7 +447,6 @@
   table.flextable .invisible,
   table#noarticletext,
   table#noarticletext table,
-  :not(.color_swatch) > div[style*="background"]:not([style*="#90EE90"]),
   .navbox-list,
   .mw-wsmfinal-content,
   .mw-body-content,
@@ -590,8 +589,6 @@
   span[style*="color:#555555"],
   td[style^="background: #FFFFFF" i],
   td[style^="background:#FFFFFF" i],
-  td[style^="background: #F5F" i],
-  td[style^="background:#F5F" i],
   div[style*="color"]:not([style*="black;"]):not([style*="back"]):not([style*="966"]):not([style*="red"]),
   div.flaggedrevs_preview,
   div.plainlinks,
@@ -621,7 +618,9 @@
   #footer li,
 	.vector-feature-zebra-design-disabled .vector-main-menu-landmark div > div,
 	.vector-feature-zebra-design-disabled #vector-page-tools > div div,
-	.frb-inline-main .cta {
+	.frb-inline-main .cta,
+	.cx-uls-entrypoint.cx-uls-entrypoint,
+	.mw-electronpdfservice-selection-form label {
     color: var(--gray-c) !important;
   }
   a,
@@ -741,7 +740,7 @@
     color: var(--base-color);
     box-shadow: inset 0 -2px 0 0 var(--base-color);
   }
-  tt,
+
   tt[style*="background: white"] {
     background: var(--gray-1) !important;
   }
@@ -758,7 +757,11 @@
   .mw-echo-ui-toggleReadCircleButtonWidget:hover .mw-echo-ui-toggleReadCircleButtonWidget-circle-unread {
     background-color: var(--gray-2f) !important;
   }
-  .mw-collapsible:not([class*="navbox-"]):not([class*="wpb"]) th:not(.wikidatainfobox-lcell):not([style*="cfe3ff;"]):not([style*="text"]):not([style*="#fff1d2;"]):not([style*="transparent"]):not([colspan="3"]):not(.mbox-text), .infobox th.infobox-above.fn[style*="background-color"] {
+  .mw-collapsible:not([class*="navbox-"]):not([class*="wpb"]) th:not(.wikidatainfobox-lcell):not([style*="cfe3ff;"]):not([style*="text"]):not([style*="#fff1d2;"]):not([style*="transparent"]):not([colspan="3"]):not(.mbox-text),
+.infobox th.infobox-above.fn[style*="background-color"],
+	.cx-uls-entrypoint__panel-container,
+	.infobox-subheader,
+	table.toccolours > caption[style*="background-color:lavender"] {
     background-color: var(--gray-3) !important;
   }
 	.cx-uls-relevant-languages-banner {
@@ -837,7 +840,11 @@
   .tux-message-item-compact,
   .nomobile.plainlist,
   .infobox td[style^="background-color:#cfea9e;"],
-  .infobox[style*="border: solid 1px silver"] {
+  .infobox[style*="border: solid 1px silver"],
+	table.toccolours tr > th[style*="border-bottom:1px solid black"],
+	table.toccolours tr > th[style*="border-bottom:1px solid #bbbbbb"],
+	table.toccolours tr > td[style*="border-bottom:1px solid #bbbbbb"],
+	table.toccolours > caption[style*="background-color:lavender"] {
     border-color: var(--gray-5) !important;
   }
   table[style*="border:1px solid #CCCCCC;"],
@@ -862,7 +869,12 @@
   .mw-parser-output .ib-settlement .mergedbottomrow .infobox-data,
 	.mw-parser-output .ib-settlement .mergedbottomrow .infobox-full-data,
   .mw-parser-output .ib-settlement .mergedbottomrow .infobox-data,
-	.ui-closeable {
+	.mw-parser-output .ib-settlement .mergedtoprow .infobox-full-data,
+	div.flaggedrevs_notice,
+	.ui-closeable,
+	.cx-uls-entrypoint__header,
+	.cx-uls-entrypoint,
+	.mw-electronpdfservice-selection-form label {
     border-color: var(--gray-5);
   }
   .uls-settings-trigger {
@@ -917,7 +929,8 @@
   .infobox-above[style*="background:#ccc"],
   .infobox-above[style*="background: #DEDEE2;"],
   .infobox-above[style*="background-color: #E7DCC3;"],
-  .infobox-above[style="background:Silver"] {
+  .infobox-above[style="background:Silver"],
+	.wikitable[style*="background-color:#f7f8ff"] tbody {
     background-color: var(--gray-3) !important;
   }
   .ve-ui-mwParameterResultWidget.oo-ui-optionWidget-highlighted,
@@ -1236,7 +1249,8 @@
   .NavFrame,
   .divbox,
   .vertical-navbox:not(.nowraplinks),
-  .mw-advancedSearch-fieldContainer .oo-ui-labelElement > .oo-ui-fieldsetLayout-header > .oo-ui-labelElement-label {
+  .mw-advancedSearch-fieldContainer .oo-ui-labelElement > .oo-ui-fieldsetLayout-header > .oo-ui-labelElement-label,
+	.mw-parser-output > div[dir="ltr"][style^="background: #ffffee;"] {
     background-color: var(--gray-2) !important;
   }
   table[style*="background-color: #f9f9f9; border: 1px solid #aaa;"] {
@@ -1301,7 +1315,8 @@
   }
   .vector-feature-page-tools-enabled #vector-main-menu-pinned-container .vector-main-menu,
   .vector-feature-page-tools-disabled .vector-main-menu,
-  .vector-pinnable-element, .vector-feature-zebra-design-disabled #vector-main-menu-pinned-container .vector-main-menu {
+  .vector-pinnable-element, .vector-feature-zebra-design-disabled #vector-main-menu-pinned-container .vector-main-menu,
+  .vector-feature-zebra-design-disabled .vector-toc {
     background-color: var(--black_17);
   }
   .vector-feature-page-tools-enabled .vector-pinnable-element > :not(:last-child),
@@ -1331,6 +1346,17 @@
     background-color: var(--gray-a);
     color: var(--gray-d);
   }
+ .cx-source-title,
+ .mw-logo-page-title {
+    color: var(--gray-d) !important;
+  }		
+	.cx-target-title,
+	.cx-last-updated {
+    color: var(--gray-c) !important;
+  }
+	.cx-translation-filter {
+		box-shadow: 0 4px 4px -4px var(--gray-5);
+ }
   .cdx-button:not(.cdx-button--type-quiet):enabled {
     background-color: var(--gray-a);
     border-color: var(--gray-5);
@@ -1615,7 +1641,8 @@
   #mwe-popups-settings,
   #mw-searchoptions,
   #pagehistory li.selected,
-  #js-lang-lists .text {
+  #js-lang-lists .text,
+  .tooltipContent > div {
     background-color: var(--gray-2) !important;
   }
   #advancedSearchField-plain,
@@ -1785,7 +1812,7 @@
   table.nmbox th:not([style*="#EEF"]),
   table.wikitable > * > tr > th:not([style*="#ABC;"]):not([style*="#fdb"]):not([style*="#fed"]):not([style*="#fef"]):not([style*="#d4f"]):not([style*="0; color:#000000"]):not([style*="FF; color:#000000"]),
   table.wikitable > tbody > tr[style*="background-color:#F6F6F6" i],
-  td[style*="background"]:not([style*="D8B"]):not([style*="000"]):not([style*="cdde"]):not([style*="e8dbae"]):not([style*="FE4"]):not([style*="301"]):not([style*="722"]):not([style*="781"]):not([style*="702"]):not([style*="6C3"]):not([style*="880"]):not([style*="866"]):not([style*="512"]):not([style*="DE6"]):not([style*="C54"]):not([style*="B76"]):not([style*="9A4"]):not([style*="4E2"]):not([style*="DF0"]):not([style*="DA7"]):not([style*="DF7"]):not([style*="9F00"]):not([style*="FAE6"]):not([style*="E0B0"]):not([style*="800080"]):not([style*="66023C"]):not([style*="7851A9"]):not([style*="C71585"]):not([style*="BF00FF"]):not([style*="A020F0"]):not([style*="9370DB"]):not([style*="663399"]),
+  td[style*="background"]:not([style*="D8B"]):not([style*="000"]):not([style*="cdde"]):not([style*="e8dbae"]):not([style*="FE4"]):not([style*="301"]):not([style*="722"]):not([style*="781"]):not([style*="702"]):not([style*="6C3"]):not([style*="880"]):not([style*="866"]):not([style*="512"]):not([style*="DE6"]):not([style*="C54"]):not([style*="B76"]):not([style*="9A4"]):not([style*="4E2"]):not([style*="DF0"]):not([style*="DA7"]):not([style*="DF7"]):not([style*="9F00"]):not([style*="FAE6"]):not([style*="E0B0"]):not([style*="800080"]):not([style*="66023C"]):not([style*="7851A9"]):not([style*="C71585"]):not([style*="BF00FF"]):not([style*="A020F0"]):not([style*="9370DB"]):not([style*="663399"]):not(.notheme),
   td[style*="background:#F2F2F2" i],
   td[style*="background: #ececec;" i],
   th[style*="background:#eee" i],
@@ -1885,7 +1912,8 @@
     border-color: var(--gray-2) !important;
   }
   .mw-logo-container > img,
-  a img[src*="WRN_header.png"] {
+  a img[src*="WRN_header.png"],
+  .mw-logo-wordmark {
     filter: invert(88%);
   }
   kbd,
@@ -2078,7 +2106,8 @@
   .mw-mmv-next-image,
   .mw-mmv-prev-image,
   .mw-page-container,
-  #mw-panel {
+  #mw-panel,
+	.cx-translation-filter {
     background-color: transparent !important;
     border: none !important;
   }
@@ -2786,9 +2815,6 @@
     background-color: var(--gray-28) !important;
     border-color: var(--gray-5) !important;
   }
-  td[style*="background: #F5F5FF"] {
-    background-color: var(--gray-28) !important;
-  }
   .oo-ui-menuSelectWidget {
     background-color: var(--gray-18);
     border-color: var(--gray-5);
@@ -3316,7 +3342,10 @@
 	}
   .mw-parser-output .navbox,
   .mw-parser-output .navbox-subgroup,
-	.mw-parser-output .navbox > .caption {
+	.mw-parser-output .navbox > .caption,
+	.mw-parser-output .fileinfo-paramfield,
+	.mw-parser-output .navbox > .mw-collapsible-content > .above,
+	.mw-parser-output .navbox > .mw-collapsible-content > .below{
     background-color: var(--purple-1);
   }
   .mw-parser-output .navbox,
@@ -3983,7 +4012,10 @@
   #talkheader td,
   #mwe-popups-settings,
   #mwe-popups-settings header,
-  .infobox-below[style="border-top:1px #aaa solid;"] {
+  .infobox-below[style="border-top:1px #aaa solid;"],
+	.mw-parser-output table[style*="border:solid 1px silver"],
+	.thumbcaption > span,
+  .tooltipContent > div {
     border-color: var(--gray-5) !important;
   }
   div[style*="border:1px #FFFFFF" i],
@@ -3999,8 +4031,8 @@
   }
   /* stop hovering effects on tr/td borders
 	   https://species.wikimedia.org/wiki/Wikispecies:Templates#Link_Templates */
-  tr:hover,
-  td:not(.mid-table):not([style*="border:1px solid transparent"]):not(.navbox-abovebelow):not(.navbox-list):not([style]):not(.MainPageBG):not(.infobox-image):not(.navbox-even):not(.navbox-odd):hover {
+  table:not(.inner-standard) > tbody > tr:hover,
+  table:not(.inner-standard) > tbody > tr > td:not(.mid-table):not([style*="border:1px solid transparent"]):not(.navbox-abovebelow):not(.navbox-list):not([style]):not(.MainPageBG):not(.infobox-image):not(.navbox-even):not(.navbox-odd):hover, .ibox-inner > tbody > tr > th[colspan] {
     border-color: var(--gray-5) !important;
   }
   .tux-workflow-status:hover {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -850,7 +850,8 @@
   .ve-ui-cxDesktopContext .ve-ui-cxLinkContextItem-sourceBody,
   .sidebar.WSerieV,
   .ve-ui-mwTransclusionDialog-addParameterFieldset .ve-ui-mwParameterSearchWidget,
-  .mw-parser-output .portalborder {
+  .mw-parser-output .portalborder,
+	.mw-collapsible-toggle-default {
     border-color: var(--gray-5);
   }
   .uls-settings-trigger {
@@ -1144,7 +1145,9 @@
     color: var(--gray-c) !important;
   }
   .suggestion-description,
-  .mw-mmv-credit {
+  .mw-mmv-credit,
+	.mw-collapsible-toggle-default::before,
+	.mw-collapsible-toggle-default::after {
     color: var(--gray-b9);
   }
   .suggestion-link.active {
@@ -1997,8 +2000,8 @@
   }
   img[src*="9px-AnonEditWarning"],
   a img[src*="OOjs_UI_icon"],
-  span.mw-ui-icon::before,
-  .vector-dropdown > .vector-menu-heading::after,
+  span.mw-ui-icon:not(.mw-ui-icon-language-progressive)::before,
+  .vector-dropdown > .vector-menu-heading:not(.vector-menu-heading)::after,
   .mw-interlanguage-selector::after,
   .uls-menu.uls-language-actions-dialog .uls-language-actions-title .uls-language-actions-close,
   .oo-ui-icon-ellipsis,
@@ -3823,7 +3826,8 @@
  .mw-guidedtour-tour-WlFiltersIntro,
  .mw-parser-output .infobox td,
  .mw-parser-output .infobox th,
- #preferences .mw-htmlform-submit-buttons {
+ #preferences .mw-htmlform-submit-buttons,
+ .mw-parser-output .side-box {
     border-color: var(--gray-5);
   }
   body[class*="skin-"] .mw-parser-output table.ambox {
@@ -3955,7 +3959,8 @@
   .vector-menu-content,
   #talkheader td,
   #mwe-popups-settings,
-  #mwe-popups-settings header {
+  #mwe-popups-settings header,
+  .infobox-below[style="border-top:1px #aaa solid;"] {
     border-color: var(--gray-5) !important;
   }
   div[style*="border:1px #FFFFFF" i],
@@ -7629,12 +7634,18 @@
   #main-page-wikimedia {
     background: var(--gray-18);
   }
-  #mw-content-text .cytat {
-    background-color: var(--gray-3);
+  #mw-content-text .cytat, .mw-parser-output .naglowek {
+    background-color: var(--gray-3) !important;
   }
+	.infobox .grafika {
+    background-color: var(--gray-2) !important;
+	}
   #main-page-welcome strong {
-    color: var(--gray-18);
+    color: var(--gray-18) !important;
   }
+	.mw-parser-output .naglowek {
+		color: var(--gray-c) !important;
+	}
   #main-page #main-page-content h2 {
     background: linear-gradient(to right, var(--blue-1) 0%, transparent 90%);
     background-image: none;
@@ -7654,7 +7665,7 @@
     border-color: var(--green-3);
   }
   #main-page #main-page-header,
-  #main-page #main-page-wiki-events {
+  #main-page #main-page-wiki-events, .infobox > caption {
     border-color: var(--gray-5);
   }
   .tool-button {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -425,7 +425,10 @@
   .mw-body[role="main"],
   .skin-vector-max-width .mw-page-container,
   .skin-vector #mw-panel,
-  .mw-page-container {
+  .mw-page-container,
+	.vector-feature-zebra-design-disabled body,
+	.vector-feature-zebra-design-disabled .vector-header-container,
+	#preferences .mw-htmlform-submit-buttons {
     background-color: var(--gray-2);
     background-image: var(--bg-selected);
     background-clip: border-box;
@@ -612,7 +615,10 @@
   .vertical-navbox th span,
   .mw-mmv-post-image,
   .mw-mmv-permission-box .mw-mmv-permission-text,
-  #footer li {
+  #footer li,
+	.vector-feature-zebra-design-disabled .vector-main-menu-landmark div > div,
+	.vector-feature-zebra-design-disabled #vector-page-tools > div div,
+	.frb-inline-main .cta {
     color: var(--gray-c) !important;
   }
   a,
@@ -749,9 +755,17 @@
   .mw-echo-ui-toggleReadCircleButtonWidget:hover .mw-echo-ui-toggleReadCircleButtonWidget-circle-unread {
     background-color: var(--gray-2f) !important;
   }
-  .mw-collapsible:not([class*="navbox-"]):not([class*="wpb"]) th:not(.wikidatainfobox-lcell):not([style*="cfe3ff;"]):not([style*="text"]):not([style*="#fff1d2;"]):not([style*="transparent"]):not([colspan="3"]):not(.mbox-text) {
+  .mw-collapsible:not([class*="navbox-"]):not([class*="wpb"]) th:not(.wikidatainfobox-lcell):not([style*="cfe3ff;"]):not([style*="text"]):not([style*="#fff1d2;"]):not([style*="transparent"]):not([colspan="3"]):not(.mbox-text), .infobox th.infobox-above.fn[style*="background-color"] {
     background-color: var(--gray-3) !important;
   }
+	.cx-uls-relevant-languages-banner {
+		background-color: var(--gray-3) !important;
+		color: var(--gray) !important;
+	}
+								 
+	.cx-uls-relevant-languages-banner__icon {
+		filter: invert(0.8) !important;
+	}
   .oo-ui-toolbar-bar,
   .oo-ui-window-head,
   .oo-ui-window-foot,
@@ -768,7 +782,9 @@
   .oo-ui-tool.oo-ui-widget-enabled > .oo-ui-tool-link:active:focus,
   .oo-ui-tool.oo-ui-widget-enabled.oo-ui-tool-active > .oo-ui-tool-link,
   .oo-ui-tool.oo-ui-widget-enabled.oo-ui-popupToolGroup-active > .oo-ui-tool-link,
-  .oo-ui-listToolGroup-tools .oo-ui-tool.oo-ui-widget-enabled:hover {
+  .oo-ui-listToolGroup-tools .oo-ui-tool.oo-ui-widget-enabled:hover,
+  .vector-feature-zebra-design-disabled .vector-dropdown .vector-dropdown-content,
+	.vector-feature-zebra-design-disabled .vector-dropdown > .vector-menu-content {
     background-color: var(--gray-3);
   }
   :not(.color_swatch) > div[style*="background-color: rgb(249, 249, 249)"] {
@@ -1267,7 +1283,7 @@
   }
   .vector-feature-page-tools-enabled #vector-main-menu-pinned-container .vector-main-menu,
   .vector-feature-page-tools-disabled .vector-main-menu,
-  .vector-pinnable-element {
+  .vector-pinnable-element, .vector-feature-zebra-design-disabled #vector-main-menu-pinned-container .vector-main-menu {
     background-color: var(--black_17);
   }
   .vector-feature-page-tools-enabled .vector-pinnable-element > :not(:last-child),
@@ -1594,7 +1610,8 @@
   .mw-parser-output table.floatright[width="35%"] {
     background: none;
   }
-  #vector-toc-pinned-container .vector-toc:after {
+  #vector-toc-pinned-container .vector-toc:after,
+	.vector-page-tools::after {
     background: transparent !important;
   }
   table[style*="background: transparent"],
@@ -1987,8 +2004,10 @@
   .oo-ui-icon-ellipsis,
   .mw-ui-icon-ellipsis::before,
   .mw-ui-icon.mw-ui-icon-before::before,
-  .mw-ui-icon.mw-ui-icon-element::before,
-  .mw-parser-output .helpContents-icon {
+  .mw-ui-icon.mw-ui-icon-element:not(.mw-ui-icon-bell):not(.mw-ui-icon-tray)::before,
+  .mw-parser-output .helpContents-icon,
+	.mw-ui-icon-wikimedia-bell,
+	.mw-ui-icon-wikimedia-tray {
     filter: invert(80%);
   }
   .k-player .control-bar {
@@ -3793,7 +3812,18 @@
   #content,
   #filetoc,
   #toc,
-  #uls-settings-block {
+  #uls-settings-block,
+ .vector-feature-zebra-design-disabled .vector-pinnable-element > :not(:last-child),
+ .vector-feature-zebra-design-disabled .vector-dropdown-content > :not(:last-child),
+ .mw-footer,
+ .vector-feature-zebra-design-disabled .vector-sticky-header-container,
+ .vector-feature-zebra-design-disabled .vector-sticky-header-context-bar,
+ .ve-ui-mwLanguagesPage-languages-table th,
+ .ve-ui-mwLanguagesPage-languages-table td,
+ .mw-guidedtour-tour-WlFiltersIntro,
+ .mw-parser-output .infobox td,
+ .mw-parser-output .infobox th,
+ #preferences .mw-htmlform-submit-buttons {
     border-color: var(--gray-5);
   }
   body[class*="skin-"] .mw-parser-output table.ambox {
@@ -3942,7 +3972,7 @@
   /* stop hovering effects on tr/td borders
 	   https://species.wikimedia.org/wiki/Wikispecies:Templates#Link_Templates */
   tr:hover,
-  td:not(.mid-table):not([style*="border:1px solid transparent"]):not(.navbox-abovebelow):not(.navbox-list):not([style]):not(.MainPageBG):hover {
+  td:not(.mid-table):not([style*="border:1px solid transparent"]):not(.navbox-abovebelow):not(.navbox-list):not([style]):not(.MainPageBG):not(.infobox-image):hover {
     border-color: var(--gray-5) !important;
   }
   .tux-workflow-status:hover {
@@ -4136,13 +4166,18 @@
   .oo-ui-image-progressive.oo-ui-icon-wikiText,
   .oo-ui-image-progressive.oo-ui-icon-eye,
   .mw-ui-icon-eye-progressive::before,
-  .oo-ui-popupToolGroup.oo-ui-widget-enabled > .oo-ui-popupToolGroup-handle .oo-ui-iconElement-icon,
   .oo-ui-image-progressive.oo-ui-icon-specialCharacter,
   .mw-ui-icon-specialCharacter-progressive::before,
   .oo-ui-image-progressive.oo-ui-icon-help,
   .mw-ui-icon-help-progressive::before {
     filter: grayscale(1) brightness(230%);
   }
+ .ve-ui-mwLanguagesPage-languages-table tr:nth-child(2n) td {
+	  background-color: var(--gray-3) !important;
+	}
+ .ve-ui-mwLanguagesPage-languages-table tr:nth-child(2n+1) td {
+	  background-color: var(--gray-4) !important;
+	}
   .mwe-popups.flipped_y::after,
   .mwe-popups.flipped_x_y::after,
   .mwe-popups.flipped-y::after,

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -467,7 +467,7 @@
   .wikitable > tr > td,
   .wikitable > * > tr,
   .wikitable > * > tr > th,
-  .wikitable > * > tr > td:not(.break),
+  .wikitable > * > tr > td:not(.break):not([style^="background:"]):not([bgcolor]),
   .wikitable th span[style*="background"],
   .inline-quote-talk,
   .oo-ui-fieldsetLayout-group .oo-ui-widget,
@@ -475,6 +475,9 @@
   .mw-parser-output .mod-gallery .gallerybox div,
   #mp-topbanner {
     background-color: transparent !important;
+  }
+  tr > td[bgcolor] {
+    color: var(--gray-1) !important;
   }
   .color_swatch div[style*="background"] {
     color: var(--white_25) !important;
@@ -851,7 +854,15 @@
   .sidebar.WSerieV,
   .ve-ui-mwTransclusionDialog-addParameterFieldset .ve-ui-mwParameterSearchWidget,
   .mw-parser-output .portalborder,
-	.mw-collapsible-toggle-default {
+	.mw-collapsible-toggle-default,
+	.mw-parser-output .ib-settlement .mergedtoprow .infobox-header,
+	.mw-parser-output .ib-settlement .mergedtoprow .infobox-label,
+	.mw-parser-output .ib-settlement .mergedtoprow .infobox-data,
+	.mw-parser-output .ib-settlement .mergedbottomrow .infobox-label,
+  .mw-parser-output .ib-settlement .mergedbottomrow .infobox-data,
+	.mw-parser-output .ib-settlement .mergedbottomrow .infobox-full-data,
+  .mw-parser-output .ib-settlement .mergedbottomrow .infobox-data,
+	.ui-closeable {
     border-color: var(--gray-5);
   }
   .uls-settings-trigger {
@@ -859,9 +870,13 @@
   }
   .vector-search-box-collapses #searchButton,
   .vector-search-box-collapses #mw-searchButton,
-  .wikibase-toolbar-container.wikibase-toolbar-container {
+  .wikibase-toolbar-container.wikibase-toolbar-container,
+	.thumbinner > .tsingle > .thumbimage{
     background: transparent !important;
   }
+	.wb-preferred .wikibase-statementview-mainsnak {
+		background-color: var(--green-a0) !important;
+	}
   .mw-parser-output .maf-info,
   .mw-parser-output .wwikipedii tr {
     background-color: var(--gray-18);
@@ -1790,7 +1805,7 @@
   p[style*="background-color:#F7FAFC" i],
   :not(.color_swatch) > div[style*="background-color: #dddddd" i],
   .infobox.standard-talk tr[style*="#e8dbae"],
-  .infobox th[style*="background"]:not([style*="green"]):not([style*="background:#dfc;"]):not(.infobox-above):not([style*="lavender"]):not([style*="cfe3ff"]):not([style*="rgb(235,235,210)"]):not([style*="antiquewhite"]),
+  .infobox th[style*="background"]:not([style*="green"]):not([style*="background:#dfc;"]):not([style*="lavender"]):not([style*="cfe3ff"]):not([style*="rgb(235,235,210)"]):not([style*="antiquewhite"]),
   .infobox tr[style*="background-color"]:not([style*="cedff2"]),
   .infobox,
   .tlheader,
@@ -1819,6 +1834,9 @@
   .navbox-subgroup .navbox-title {
     background-color: var(--gray-5);
   }
+	.navbox-title > div {
+		color: var(--black) !important;
+	}
   .mw-revslider-revision,
   .cbnnr-close {
     background-color: var(--gray-7);
@@ -1898,6 +1916,14 @@
   .mw-ui-button.mw-ui-progressive:focus:not(:active) {
     box-shadow: inset 0 0 0 1px var(--base-color), inset 0 0 0 2px var(--gray-a) !important;
   }
+	input[type="checkbox"]:focus + .mw-ui-button.mw-ui-quiet,
+	input[type="checkbox"]:focus + .mw-ui-button.mw-ui-quiet.mw-ui-progressive,
+	input[type="checkbox"]:focus + .mw-ui-button.mw-ui-quiet.mw-ui-destructive,
+	.mw-ui-button.mw-ui-quiet:focus,
+	.mw-ui-button.mw-ui-quiet.mw-ui-progressive:focus,
+	.mw-ui-button.mw-ui-quiet.mw-ui-destructive:focus {
+	box-shadow: inset 0 0 0 1px #36c,inset 0 0 0 2px var(--gray-4) !important;
+}				 
   .oo-ui-popupToolGroup-tools .oo-ui-tool.oo-ui-widget-enabled .oo-ui-tool-link:focus {
     outline: 0;
     box-shadow: inset 0 0 0 2px var(--base-color);
@@ -3283,16 +3309,14 @@
     background: var(--purple-1) !important;
     border-color: var(--purple-1) !important;
   }
-  table.navbox th,
-  .navbox-title,
-  .navbox-title *,
-  .navbox th {
-    background: var(--purple-0) !important;
-    border-color: var(--gray-2) !important;
-    color: var(--gray-c) !important;
-  }
+	.mw-parser-output .navbox .inner-standard > tbody > tr > th + td,
+	.mw-parser-output .navbox .inner-standard > tbody > tr + tr > th,
+	.mw-parser-output .navbox .inner-standard > tbody > tr + tr > td {
+		border-color: var(--gray-4) !important;
+	}
   .mw-parser-output .navbox,
-  .mw-parser-output .navbox-subgroup {
+  .mw-parser-output .navbox-subgroup,
+	.mw-parser-output .navbox > .caption {
     background-color: var(--purple-1);
   }
   .mw-parser-output .navbox,
@@ -3579,7 +3603,6 @@
     border-color: var(--yellow-1);
   }
   tr[style*="background:orange" i],
-  td[style*="background:#ffd" i],
   .table-partial {
     background-color: var(--brown-1) !important;
   }
@@ -3977,7 +4000,7 @@
   /* stop hovering effects on tr/td borders
 	   https://species.wikimedia.org/wiki/Wikispecies:Templates#Link_Templates */
   tr:hover,
-  td:not(.mid-table):not([style*="border:1px solid transparent"]):not(.navbox-abovebelow):not(.navbox-list):not([style]):not(.MainPageBG):not(.infobox-image):hover {
+  td:not(.mid-table):not([style*="border:1px solid transparent"]):not(.navbox-abovebelow):not(.navbox-list):not([style]):not(.MainPageBG):not(.infobox-image):not(.navbox-even):not(.navbox-odd):hover {
     border-color: var(--gray-5) !important;
   }
   .tux-workflow-status:hover {


### PR DESCRIPTION
Hello,
Below are my fixes to new style - removing dark text, white backgrounds, titles backgrounds on infoboxes, editing articles icons or preferences stuff.

Example screen:
![obraz](https://user-images.githubusercontent.com/34380553/234979003-cfd5a7ce-78fa-496f-98b0-428721701084.png)
