### PR TITLE
Fixes to backgrounds, infoboxes and font colors

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1437,14 +1437,11 @@
     border-top: 1px solid var(--gray-3);
   }
   .vector-menu-heading-label,
-  .cdx-button::after,
-						   
+  .cdx-button .vector-icon:not(.mw-ui-icon-wikimedia-language-progressive),
+  .cdx-button:not([for="p-lang-btn-checkbox"])::after,
   .vector-menu-content .vector-icon {
     filter: invert(75%);
   }
-					
-						 
-   
   input:hover + .vector-menu-heading.cdx-button.cdx-button--action-progressive,
   .cdx-button--weight-quiet.cdx-button--action-progressive:enabled:hover,
   .cdx-button--weight-quiet.cdx-button--action-progressive.cdx-button--fake-button--enabled:hover {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -427,13 +427,14 @@
   .skin-vector #mw-panel,
   .mw-page-container,
   .vector-feature-zebra-design-disabled body,
-  .vector-feature-zebra-design-disabled .vector-header-container,
   #preferences .mw-htmlform-submit-buttons,
   .vector-feature-zebra-design-enabled .vector-header-container,
   .vector-feature-zebra-design-disabled .mw-page-container,
   .vector-feature-zebra-design-enabled .vector-page-titlebar,
   .vector-feature-zebra-design-enabled .vector-page-toolbar,
-  .vector-feature-zebra-design-enabled .vector-body {
+  .vector-feature-zebra-design-enabled .vector-body,
+	.vector-feature-zebra-design-enabled .vector-header-container .vector-sticky-header,
+	.vector-feature-zebra-design-enabled .mw-page-container {
     background-color: var(--gray-2);
     background-image: var(--bg-selected);
     background-clip: border-box;
@@ -471,13 +472,14 @@
   .wikitable > tr > td,
   .wikitable > * > tr,
   .wikitable > * > tr > th,
-  .wikitable > * > tr > td:not(.break):not([style^="background:"]):not([bgcolor]),
+  .wikitable > * > tr > td:not(.break):not([style^="background:"]):not([bgcolor]):not([style*="background:#"][style*="color:#000"]),
   .wikitable th span[style*="background"],
   .inline-quote-talk,
   .oo-ui-fieldsetLayout-group .oo-ui-widget,
   .mw-parser-output .mod-gallery .whitebg img,
   .mw-parser-output .mod-gallery .gallerybox div,
-  #mp-topbanner {
+  #mp-topbanner,
+  figure[typeof~="mw:File/Thumb"], figure[typeof~="mw:File/Frame"] {
     background-color: transparent !important;
   }
   tr > td[bgcolor] {
@@ -505,7 +507,8 @@
     background-color: transparent !important;
   }
   div.vectorTabs li.selected,
-  .vector-header-container,
+  .vector-feature-zebra-design-enabled .vector-header-container .mw-header,
+  .vector-feature-zebra-design-disabled .vector-header-container,
   .mw-mmv-image-metadata,
   .navbox,
   .navbox-subgroup,
@@ -571,6 +574,7 @@
     color: var(--gray-c);
   }
   .cdx-text-input__input:enabled ~ .cdx-text-input__icon,
+  .vector-feature-zebra-design-enabled .vector-sticky-header.vector-header-search-toggled .vector-search-box-show-thumbnail .cdx-text-input__start-icon,
   .vector-feature-zebra-design-disabled .vector-sticky-header.vector-header-search-toggled .vector-search-box-show-thumbnail .cdx-text-input__start-icon,
   .oo-ui-listToolGroup.oo-ui-widget-disabled,
   .oo-ui-listToolGroup-tools .oo-ui-tool.oo-ui-widget-disabled .oo-ui-tool-title,
@@ -796,7 +800,6 @@
   .oo-ui-tool.oo-ui-widget-enabled.oo-ui-tool-active > .oo-ui-tool-link,
   .oo-ui-tool.oo-ui-widget-enabled.oo-ui-popupToolGroup-active > .oo-ui-tool-link,
   .oo-ui-listToolGroup-tools .oo-ui-tool.oo-ui-widget-enabled:hover,
-  .vector-feature-zebra-design-disabled .vector-dropdown .vector-dropdown-content,
   .vector-feature-zebra-design-disabled .vector-dropdown > .vector-menu-content {
     background-color: var(--gray-3);
   }
@@ -854,7 +857,9 @@
   table.toccolours > caption[style*="background-color:lavender"],
   .infobox-header[style^="border-top:#aaa 1px solid"],
   .infobox-below[style="border-top:#aaa 1px solid"],
-  .mw-ui-icon-small.vector-toc-toggle {
+  .mw-ui-icon-small.vector-toc-toggle,
+  figure[typeof~="mw:File/Thumb"], figure[typeof~="mw:File/Frame"],
+  figure[typeof~="mw:File/Thumb"] > :not(figcaption) .mw-file-element {
     border-color: var(--gray-5) !important;
   }
   table[style*="border:1px solid #CCCCCC;"],
@@ -906,7 +911,8 @@
   .wikibase-toolbar-container.wikibase-toolbar-container,
   .thumbinner > .tsingle > .thumbimage,
   .vector-feature-zebra-design-enabled .vector-pinned-container::after,
-  .vector-feature-zebra-design-enabled .vector-dropdown .vector-dropdown-content::after {
+  .vector-feature-zebra-design-enabled .vector-dropdown .vector-dropdown-content::after,
+  .vector-feature-zebra-design-enabled .vector-sticky-pinned-container::after {
     background: transparent !important;
   }
   .wb-preferred .wikibase-statementview-mainsnak {
@@ -953,7 +959,8 @@
   .infobox-above[style*="background: #DEDEE2;"],
   .infobox-above[style*="background-color: #E7DCC3;"],
   .infobox-above[style="background:Silver"],
-  .wikitable[style*="background-color:#f7f8ff"] tbody {
+  .wikitable[style*="background-color:#f7f8ff"] tbody,
+  input:hover + .cdx-button.cdx-button--action-progressive {
     background-color: var(--gray-3) !important;
   }
   .ve-ui-mwParameterResultWidget.oo-ui-optionWidget-highlighted,
@@ -1306,6 +1313,8 @@
   input.mw-ui-input:focus {
     box-shadow: inset 0 0 0 1px var(--base-color) !important;
   }
+  #vector-toc-pinned-container .vector-toc::after,
+  #vector-toc-pinned-container .sidebar-toc::after,
   .vector-feature-zebra-design-disabled .vector-sticky-pinned-container::after {
     background: linear-gradient(transparent, var(--gray-1));
   }
@@ -1339,14 +1348,23 @@
   .vector-dropdown-content > :not(:last-child) {
     border-bottom: 1px solid var(--gray-7);
   }
+  .vector-feature-zebra-design-disabled #vector-main-menu-pinned-container .vector-main-menu,
   .vector-feature-page-tools-enabled #vector-main-menu-pinned-container .vector-main-menu,
   .vector-feature-page-tools-disabled .vector-main-menu,
   .vector-pinnable-element,
-  .vector-feature-zebra-design-disabled #vector-main-menu-pinned-container .vector-main-menu,
   .vector-feature-zebra-design-disabled .vector-toc,
+  .vector-feature-zebra-design-disabled .vector-pinned-container:not(#vector-main-menu-pinned-container):not(#vector-toc-pinned-container),
   .vector-feature-zebra-design-enabled .vector-pinned-container,
+  .vector-feature-zebra-design-enabled #vector-toc-pinned-container,
   .labelced-page-type-content.ambox-content {
     background-color: var(--black_17);
+  }
+  div:not(.vector-unpinned-container) > .vector-pinnable-element {
+    padding-bottom: 1em;
+  }
+  .vector-feature-zebra-design-enabled .vector-sticky-pinned-container::after,
+  .vector-feature-zebra-design-disabled .vector-sticky-pinned-container::after {
+    background: transparent;
   }
   .vector-feature-page-tools-enabled .vector-pinnable-element > :not(:last-child),
   .vector-feature-page-tools-disabled .vector-main-menu-group .vector-menu-heading,
@@ -1373,6 +1391,10 @@
   .cdx-button--weight-quiet.cdx-button--fake-button--enabled:hover {
     background-color: var(--gray-3);
   }
+  input:active + .cdx-button:not(.cdx-button--action-progressive) {
+    background-color: var(--gray-3_5);
+    color: var(--gray-d);
+  }
   .cdx-button:not(.cdx-button--weight-quiet):enabled,
   .cdx-button:not(.cdx-button--weight-quiet).cdx-button--fake-button--enabled {
     background-color: var(--gray-a);
@@ -1397,6 +1419,8 @@
   .cdx-button:not(.cdx-button--weight-quiet).cdx-button--fake-button--enabled {
     background-color: var(--black_8);
   }
+  .vector-feature-zebra-design-disabled .vector-dropdown .vector-dropdown-content,
+  .vector-feature-zebra-design-enabled .vector-dropdown-content,
   .cdx-menu {
     background-color: var(--gray-2);
     border: 1px solid var(--gray-4);
@@ -1414,13 +1438,13 @@
   }
   .vector-menu-heading-label,
   .cdx-button::after,
-  .cdx-button .vector-icon,
+						   
   .vector-menu-content .vector-icon {
     filter: invert(75%);
   }
-  .mw-portlet-lang {
-    filter: invert(100%);
-  }
+					
+						 
+   
   input:hover + .vector-menu-heading.cdx-button.cdx-button--action-progressive,
   .cdx-button--weight-quiet.cdx-button--action-progressive:enabled:hover,
   .cdx-button--weight-quiet.cdx-button--action-progressive.cdx-button--fake-button--enabled:hover {
@@ -1818,7 +1842,8 @@
   #mwe-pt-list-more {
     background-color: var(--gray-3); /* don't include !important flag */
   }
-  .vector-header-container.vector-sticky-header-container,
+  .vector-feature-zebra-design-disabled .vector-sticky-header-container,
+  .vector-feature-zebra-design-enabled .vector-header-container .vector-sticky-header,
   .imeselector,
   .imeselector:not(.imeselector-open):hover {
     background-color: var(--gray-18);
@@ -1865,7 +1890,7 @@
   }
   table.wikitable > tr > th,
   table.nmbox th:not([style*="#EEF"]),
-  table.wikitable > * > tr > th:not([style*="#ABC;"]):not([style*="#fdb"]):not([style*="#fed"]):not([style*="#fef"]):not([style*="#d4f"]):not([style*="0; color:#000000"]):not([style*="FF; color:#000000"]),
+  table.wikitable > * > tr > th:not([style*="#ABC;"]):not([style*="#fdb"]):not([style*="#fed"]):not([style*="#fef"]):not([style*="#d4f"]):not([style*="0; color:#000000"]):not([style*="FF; color:#000000"]):not([style*="color:#000"]),
   table.wikitable > tbody > tr[style*="background-color:#F6F6F6" i],
   table:not([style*="background:#E5E5E5"]) > tbody >tr > td[style*="background"]:not([style*="D8B"]):not([style*="000"]):not([style*="cdde"]):not([style*="e8dbae"]):not([style*="FE4"]):not([style*="301"]):not([style*="722"]):not([style*="781"]):not([style*="702"]):not([style*="6C3"]):not([style*="880"]):not([style*="866"]):not([style*="512"]):not([style*="DE6"]):not([style*="C54"]):not([style*="B76"]):not([style*="9A4"]):not([style*="4E2"]):not([style*="DF0"]):not([style*="DA7"]):not([style*="DF7"]):not([style*="9F00"]):not([style*="FAE6"]):not([style*="E0B0"]):not([style*="800080"]):not([style*="66023C"]):not([style*="7851A9"]):not([style*="C71585"]):not([style*="BF00FF"]):not([style*="A020F0"]):not([style*="9370DB"]):not([style*="663399"]):not(.notheme),
   td[style*="background:#F2F2F2" i],
@@ -3190,6 +3215,7 @@
     background: var(--blue-3) !important;
     border-color: var(--gray-4) !important;
   }
+  .cdx-menu-item--enabled.cdx-menu-item--selected,
   .mw-parser-output .taxontree-lcell,
   .mw-parser-output .wikidatainfobox-lcell,
   .mw-parser-output .ib-spaceflight .infobox-header {
@@ -3934,6 +3960,7 @@
   .vector-feature-zebra-design-disabled .vector-dropdown-content > :not(:last-child),
   .mw-footer,
   .vector-feature-zebra-design-disabled .vector-sticky-header-container,
+  .vector-feature-zebra-design-enabled .vector-header-container .vector-sticky-header,
   .vector-feature-zebra-design-disabled .vector-sticky-header-context-bar,
   .ve-ui-mwLanguagesPage-languages-table th,
   .ve-ui-mwLanguagesPage-languages-table td,
@@ -5224,7 +5251,9 @@
   #footer-icons img {
     filter: brightness(70%);
   }
-  img[alt="The Signpost"] {
+  img[alt="The Signpost"],
+  .vector-icon.mw-ui-icon-wikimedia-ellipsis,
+  .vector-icon.mw-ui-icon-wikimedia-fullScreen {
     filter: invert(60%);
   }
   .sprite.svg-translate-icon,
@@ -5959,9 +5988,13 @@
     color: var(--gray-c);
   }
   #mw-mf-page-left ul li,
+  #mw-mf-page-left ul .toggle-list-item,
   #mw-mf-page-left .secondary-action {
     background-color: var(--gray-3);
     border-color: var(--gray-5);
+  }
+  #mw-mf-page-left ul .toggle-list-item {
+    background-color: var(--black_2);
   }
   .page-list li,
   .topic-title-list li,
@@ -7753,7 +7786,8 @@
     background: var(--gray-18);
   }
   #mw-content-text .cytat,
-  .mw-parser-output .naglowek {
+  .mw-parser-output .naglowek,
+	tr[style$="background:#fff;"] {
     background-color: var(--gray-3) !important;
   }
   .infobox .grafika {


### PR DESCRIPTION
Fixed some buttons colors and backgrounds, dark text on dark backgrounds, some infoboxes and tables in EN/PL version. Includes and extends fixes related with white backgrounds and gradients in #217.

![obraz](https://github.com/StylishThemes/Wikipedia-Dark/assets/34380553/c2f3c5a4-0861-4131-918c-b41f12c171e4)