### PR TITLE
Fix filter invert on menu headings and figcaption color on dark theme (for vector legacy '2010')

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -6170,22 +6170,12 @@
   figure[typeof~="mw:File/Frame"] figcaption {
     color: var(--white) !important;
   }
-}
-
-@-moz-document regexp("https?:\/\/pt\.wikipedia\.org\/.*") {
   td.MainPageBG[style*="background-color:#f2e0ce"] {
     background-color: var(--gray-2) !important;
     color: var(--gray-c) !important;
   }
-  [style*="color:#000"],
-  [style*="color: #000"],
-  [style*="color:black"],
-  [style*="color: black"],
-  [style*="color:#000000"],
-  [style*="color: #000000"] {
-    color: var(--white) !important;
-  }
 }
+
 @-moz-document domain("wikipedia.org") {
   /*** Navigation menu logo ***/
   #p-logo a {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -6331,10 +6331,6 @@
   .mw-parser-output .current-events-sidebar > div:not(.mw-collapsible-content) {
     background-color: initial;
   }
-  td.MainPageBG[style*="background-color:#f2e0ce"] {
-    background-color: var(--gray-2) !important;
-    color: var(--gray-c) !important;
-  }
 }
 @-moz-document regexp("https?:\/\/([\w\-]{2,}\.)?wikidata\.org\/.*") {
   #p-logo .mw-wiki-logo {
@@ -6526,10 +6522,6 @@
   }
   .mw-parser-output .mp-frame {
     box-shadow: 0 0 .3em var(--gray-7);
-    }
-  td.MainPageBG[style*="background-color:#f2e0ce"] {
-    background-color: var(--gray-2) !important;
-    color: var(--gray-c) !important;
       
   }
 }

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1456,7 +1456,6 @@
   .cdx-menu--has-footer .cdx-menu-item:last-of-type:not(:first-of-type) {
     border-top: 1px solid var(--gray-3);
   }
-  .vector-menu-heading-label,
   .cdx-button .vector-icon:not(.mw-ui-icon-wikimedia-language-progressive):not(.mw-ui-icon-wikimedia-tray):not(.mw-ui-icon-wikimedia-tray):not(.mw-echo-unseen-notifications),
   .cdx-button:not([for="p-lang-btn-checkbox"]):not(.mw-ui-icon-wikimedia-tray):not(.mw-echo-unseen-notifications)::after,
   .vector-menu-content .vector-icon {
@@ -6158,9 +6157,28 @@
       background-color: var(--gray-2);
     }
   }
-  #mw-panel .portal:not(#p-navigation) .body {
+#mw-panel .portal:not(#p-navigation) .body {
     background-image: linear-gradient(to top, transparent, var(--gray-c));
     background-size: auto 1px;
+  }
+}
+
+@-moz-document regexp("https?:\/\/pt\.wikipedia\.org\/.*") {
+  td.MainPageBG[style*="background-color:#f2e0ce"] {
+    background-color: var(--gray-2) !important;
+    color: var(--gray-c) !important;
+  }
+  figure[typeof~="mw:File/Thumb"] figcaption,
+  figure[typeof~="mw:File/Frame"] figcaption {
+    color: var(--white) !important;
+  }
+  [style*="color:#000"],
+  [style*="color: #000"],
+  [style*="color:black"],
+  [style*="color: black"],
+  [style*="color:#000000"],
+  [style*="color: #000000"] {
+    color: var(--white) !important;
   }
 }
 @-moz-document domain("wikipedia.org") {
@@ -6317,6 +6335,10 @@
   }
   .mw-parser-output .current-events-sidebar > div:not(.mw-collapsible-content) {
     background-color: initial;
+  }
+  td.MainPageBG[style*="background-color:#f2e0ce"] {
+    background-color: var(--gray-2) !important;
+    color: var(--gray-c) !important;
   }
 }
 @-moz-document regexp("https?:\/\/([\w\-]{2,}\.)?wikidata\.org\/.*") {
@@ -6509,6 +6531,11 @@
   }
   .mw-parser-output .mp-frame {
     box-shadow: 0 0 .3em var(--gray-7);
+    }
+  td.MainPageBG[style*="background-color:#f2e0ce"] {
+    background-color: var(--gray-2) !important;
+    color: var(--gray-c) !important;
+      
   }
 }
 @-moz-document domain("m.wikidata.org") {
@@ -8148,6 +8175,7 @@
   a.image img[src*="Das"] {
     filter: invert(1) hue-rotate(180deg) contrast(85%) brightness(200%);
     background-color: inherit !important;
+
   }
 }
 @-moz-document domain("ru.wiktionary.org") {

--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -6163,14 +6163,19 @@
   }
 }
 
+@-moz-document regexp("https?:\/\/(([\w\-]{2,}\.)?(wiki(pedia|books|news|quote|source|versity|voyage)|wiktionary)|(www|test)\.(mediawiki|wiki(data|dot))|(meta|wikimania|commons|otrs-wiki|species|wikitech|incubator|outreach|foundation|donate)\.wikimedia)\.org\/.*"),
+               regexp("https?:\/\/wiki\.(archlinux|mozilla|nixos)\.(org|jp)\/.*$"),
+               regexp("https?:\/\/wikiless\.org\/.*$") {
+  figure[typeof~="mw:File/Thumb"] figcaption,
+  figure[typeof~="mw:File/Frame"] figcaption {
+    color: var(--white) !important;
+  }
+}
+
 @-moz-document regexp("https?:\/\/pt\.wikipedia\.org\/.*") {
   td.MainPageBG[style*="background-color:#f2e0ce"] {
     background-color: var(--gray-2) !important;
     color: var(--gray-c) !important;
-  }
-  figure[typeof~="mw:File/Thumb"] figcaption,
-  figure[typeof~="mw:File/Frame"] figcaption {
-    color: var(--white) !important;
   }
   [style*="color:#000"],
   [style*="color: #000"],


### PR DESCRIPTION
- Remove `.vector-menu-heading-label` from `filter: invert(75%)` rule — it was turning sidebar section headings (e.g. "Collaboration", "Tools") gray instead of white
- Fix `figcaption` text color inside `figure[typeof~="mw:File/Thumb"]` and `figure[typeof~="mw:File/Frame"]` — captions were rendering in black, unreadable on dark background (affects all wikis)
- Add rule for `td.MainPageBG[style*="background-color:#f2e0ce"]` — light background color was not being overridden by the dark theme, making text unreadable (affects all wikis)